### PR TITLE
Fix about attribution and teleprompter TPS fidelity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -290,6 +290,7 @@ Repo-specific design rules:
 - Treat every file under `new-design/` as a static design/prototype reference only. Production UI must be implemented as Blazor components in `src/PrompterLive.Shared`; do not ship raw `new-design` HTML as runtime UI.
 - Do not re-invent the UI when the answer should be “port the markup and classes from `new-design`”.
 - For parity tasks, port the full routed screen from its matching `new-design/*.html` reference, not just isolated high-signal blocks. Settings, Editor, Learn, Teleprompter, and Go Live must match the reference screen in layout and intended interaction while staying Blazor/C# owned.
+- About content must stay factual and current: do not invent team members or contributor names; use Managed Code attribution and official company links only.
 - Do not introduce a server host for the app runtime.
 - Preserve stable `data-testid` selectors on core flows because the Playwright suite depends on them.
 - Keep UI routes in shared route constants and keep `data-testid` names in shared UI contract constants.
@@ -320,6 +321,7 @@ Repo-specific design rules:
 - Never introduce a non-SOLID design unless the exception is explicitly documented under `exception_policy`.
 - Never force-push to `main`.
 - Never approve or merge on behalf of a human maintainer.
+- When the task explicitly needs delivery, the agent may commit, push to `main` or a feature branch, open a PR, and merge it after the required tests and validation commands pass.
 
 ### Boundaries
 
@@ -352,7 +354,9 @@ Ask first:
 - brittle selectors without `data-testid`
 - mixed-language root README or public entry docs; keep them English-only unless the user explicitly asks otherwise
 - design drift from `new-design`
+- made-up About/team content or stale attribution; About must point to real Managed Code ownership and official links
 - any visible typing latency in the editor; plain input must feel immediate with no observable delay
+- teleprompter controls that fade so much they become hard to see during real reading
 - editor keystroke paths that persist, compile, or rebuild shared session state; keep plain typing in memory and move heavier local sync to debounce or autosave
 - murky JavaScript or interop layers that keep product UI behavior in JS when Blazor can own it cleanly
 - runtime dependencies fetched from random external sources instead of vendored release artifacts

--- a/about-teleprompter-fidelity.plan.md
+++ b/about-teleprompter-fidelity.plan.md
@@ -1,0 +1,154 @@
+# About And Teleprompter Fidelity Plan
+
+## Task Goal
+
+Remove invented hardcoded About content, replace it with factual Managed Code attribution and official links, then bring the teleprompter reading experience in line with `new-design/teleprompter.html` and the TPS specification so playback is visually smooth, timing-aware, and fully covered by automated tests.
+
+## Scope
+
+### In Scope
+
+- Update the Settings About section so it no longer shows invented people and instead shows factual Managed Code ownership plus official links, including GitHub.
+- Tighten teleprompter rendering and playback so active reading does not visibly jump while words/cards advance.
+- Make teleprompter controls materially more visible during use while staying aligned with the design direction.
+- Extend teleprompter rendering to reflect the TPS cues already produced by the compiler, including color, emotion, highlight, pronunciation cues, and speed-sensitive visual spacing.
+- Add or update bUnit and Playwright coverage for About and teleprompter fidelity, including at least one end-to-end teleprompter scenario.
+- Run build and relevant verification, then format, commit, and push.
+
+### Out Of Scope
+
+- Changing TPS parsing rules in `PrompterLive.Core` unless a concrete renderer gap requires a narrowly scoped compatibility fix.
+- Redesigning routes or app shell behavior outside Settings/About and Teleprompter.
+- Adding a backend or changing runtime hosting shape.
+
+## Constraints And Risks
+
+- `new-design/teleprompter.html` remains the visual reference; parity work should preserve its structure and interaction tone.
+- Browser UI tests are the primary acceptance gate; teleprompter changes are not done until real-browser checks pass.
+- The UI suite must run in a single `dotnet test` process and not overlap with other build/test commands.
+- `About` must stay factual: no invented team members or stale attribution.
+- Teleprompter smoothing must not create delayed input, unreadable word spacing, or layout churn from width-changing state changes.
+- Files should stay within maintainability limits; if teleprompter logic needs more space, split it into focused partials/helpers instead of growing a large file further.
+
+## Testing Methodology
+
+- Use bUnit to verify About content contracts and teleprompter rendered markup/state mappings for TPS styling classes and metadata-driven output.
+- Use Playwright UI tests to verify real browser playback, focal alignment, control visibility, timing continuity, and a full teleprompter scenario with screenshots under `output/playwright/`.
+- Validate both static fidelity and dynamic behavior:
+  - About shows factual Managed Code attribution and official links.
+  - Teleprompter words preserve TPS-driven styling and pacing hints.
+  - Playback advances without vertical jump artifacts on active text.
+  - Card transitions stay smooth and time/progress continue advancing.
+  - Controls remain visibly usable against live camera/gradient backgrounds.
+- Quality bar:
+  - No teleprompter regression in relevant bUnit coverage.
+  - Relevant Playwright teleprompter flows green.
+  - Repo build green under `-warnaserror`.
+
+## Ordered Plan
+
+- [x] Step 1. Establish baseline context and failures.
+  - Read the exact About and teleprompter implementation/test files that own this work.
+  - Run the relevant baseline commands in order:
+    - `dotnet build /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx -warnaserror`
+    - `dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.App.Tests/PrompterLive.App.Tests.csproj`
+    - `dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.App.UITests/PrompterLive.App.UITests.csproj --no-build`
+  - Verification before moving on:
+    - Record every failing test and symptom below.
+    - Confirm whether teleprompter failures reproduce before code changes.
+
+- [x] Step 2. Replace hardcoded About content with factual Managed Code metadata.
+  - Update `src/PrompterLive.Shared/Settings/Components/SettingsAboutSection.razor` and its code-behind to remove invented people and add factual company attribution plus official links, including GitHub.
+  - Keep the section visually aligned with Settings design patterns and preserve existing test ids or add stable new ones if needed.
+  - Verification before moving on:
+    - Add/update bUnit assertions in `tests/PrompterLive.App.Tests/Settings/SettingsInteractionTests.cs`.
+    - Confirm no stale invented names remain via targeted search.
+
+- [x] Step 3. Expand teleprompter word rendering to honor TPS visual cues.
+  - Update teleprompter reader models/rendering so words expose the cues already emitted by `ScriptCompiler`, including stronger distinctions for emphasis/highlight, pronunciation/tooltips, emotion/color mappings, and speed-sensitive spacing.
+  - Keep speed-based letter spacing bounded so words never become mush or split into visually disconnected letters.
+  - Verification before moving on:
+    - Add/update bUnit tests under `tests/PrompterLive.App.Tests/Teleprompter/`.
+    - Use TPS-backed sample scripts to prove slow/fast/xslow/xfast, highlight, pronunciation, and emotion styling render as expected.
+
+- [x] Step 4. Remove teleprompter playback jumpiness and align transitions with the design.
+  - Refine reader alignment/transition logic and any supporting browser interop so active-word tracking and card transitions stay smooth during playback.
+  - Match the intended movement profile from `new-design/teleprompter.html` while avoiding text jumps during per-word advancement.
+  - Verification before moving on:
+    - Add/update Playwright assertions for continuity and alignment.
+    - Capture a teleprompter scenario screenshot artifact under `output/playwright/`.
+
+- [x] Step 5. Make teleprompter controls visibly usable.
+  - Update the relevant reader CSS modules so sliders, edge info, and control bar stay visible enough against the background instead of fading into near-invisibility.
+  - Keep the visual language aligned with the design reference while improving usability.
+  - Verification before moving on:
+    - Add/update browser checks that confirm control opacity/visibility at runtime.
+
+- [x] Step 6. Add a full teleprompter browser scenario.
+  - Add or extend a real Playwright scenario that opens a TPS-backed teleprompter script, starts playback, verifies styling/timing/progress/controls, and saves screenshots.
+  - Verification before moving on:
+    - Scenario passes in the browser suite.
+    - Screenshot artifacts are written under `output/playwright/`.
+
+- [x] Step 7. Run final validation and ship.
+  - Run the required verification in order:
+    - `dotnet build /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx -warnaserror`
+    - `dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.App.Tests/PrompterLive.App.Tests.csproj`
+    - `dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.App.UITests/PrompterLive.App.UITests.csproj --no-build`
+    - `dotnet test /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx`
+    - `dotnet format /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx`
+  - If green, commit with a focused message and push the current branch.
+  - Verification before moving on:
+    - All planned checklist items are complete.
+    - Working tree is clean except for intentional artifacts, if any.
+
+## Baseline Failures
+
+- [x] No pre-existing baseline failures in the relevant build, bUnit, or UI suites.
+  - Build: `dotnet build /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx -warnaserror` passed.
+  - bUnit: `dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.App.Tests/PrompterLive.App.Tests.csproj` passed with `94/94`.
+  - UI: `dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.App.UITests/PrompterLive.App.UITests.csproj --no-build` passed with `75/75`.
+  - Root-cause note: current repo baseline is green; this task will add targeted regression coverage for the requested About and teleprompter behavior.
+  - Fix status: no inherited failures to clear before implementation.
+
+## Intended Fix Tracking
+
+- [x] About invented team content removed and replaced with factual Managed Code attribution.
+- [x] Teleprompter TPS styling parity expanded beyond the current reduced class mapping.
+- [x] Teleprompter playback jumpiness eliminated or reduced to non-visible smooth motion.
+- [x] Teleprompter controls made clearly visible during live use.
+- [x] Full teleprompter browser scenario added or extended with screenshot artifacts.
+
+## Final Validation Skills
+
+- `dotnet`
+  - Reason: enforce repo-compatible build, test, and format commands for this Blazor/.NET solution.
+  - Expected outcome: green build/test/format evidence aligned with `AGENTS.md`.
+
+- `playwright`
+  - Reason: validate teleprompter behavior in a real browser and capture screenshot artifacts for the changed flow.
+  - Expected outcome: passing teleprompter scenario coverage with browser-realistic evidence.
+
+## Final Validation Results
+
+- `dotnet build /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx -warnaserror`
+  - Result: passed after implementation and again after formatting.
+- `dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.Core.Tests/PrompterLive.Core.Tests.csproj`
+  - Result: passed with `34/34`.
+- `dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.App.Tests/PrompterLive.App.Tests.csproj`
+  - Result: passed with `95/95`.
+- `dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.App.UITests/PrompterLive.App.UITests.csproj --no-build`
+  - Result: passed with `76/76`.
+- `dotnet test /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx`
+  - Result: passed for the full solution.
+- `dotnet test /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx --collect:"XPlat Code Coverage"`
+  - Result: passed for the full solution with coverage artifacts emitted for Core, App, and UI suites.
+- `dotnet format /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx`
+  - Result: passed.
+
+## Notes
+
+- `About` now uses only Managed Code and PrompterLive official links and removes invented roster content from both production UI and the design reference.
+- Teleprompter playback now pre-centers upcoming content before card activation to avoid visible jump on live reading transitions.
+- TPS shorthand inline speed tags like `[180WPM]...[/180WPM]` are now preserved by the compiler so reader timing matches TPS input.
+- End-to-end browser evidence includes the teleprompter full-flow screenshots under `output/playwright/teleprompter-product-launch/`.

--- a/docs/Features/AppVersioningAndGitHubPages.md
+++ b/docs/Features/AppVersioningAndGitHubPages.md
@@ -9,6 +9,7 @@ This flow keeps the version number automated:
 - local builds default to `0.1.0`
 - release builds derive `0.1.<run_number>` from the active release workflow run
 - the About screen reads the compiled assembly metadata instead of hardcoded copy
+- the About screen links only to official Managed Code and `managedcode/PrompterLive` resources; it must never invent a team roster
 
 ## Version And Deploy Flow
 
@@ -44,7 +45,7 @@ flowchart LR
 - `PrompterLiveBuildNumber` comes from `GITHUB_RUN_NUMBER` when CI provides it, or falls back to `0` locally.
 - `.github/workflows/deploy-github-pages.yml` resolves the release version from `VersionPrefix`, so the release tag and the compiled app version stay aligned.
 - `Program.cs` creates `IAppVersionProvider` from the compiled `PrompterLive.App` assembly metadata.
-- `SettingsAboutSection` renders that provider value in the About card subtitle.
+- `SettingsAboutSection` renders that provider value in the About card subtitle and pairs it with official Managed Code, GitHub, releases, and issues links.
 
 ## GitHub Pages Rules
 
@@ -65,6 +66,7 @@ flowchart LR
 - `.github/workflows/pr-validation.yml` runs `dotnet test tests/PrompterLive.App.Tests/PrompterLive.App.Tests.csproj --no-build`
 - `.github/workflows/pr-validation.yml` runs `dotnet test tests/PrompterLive.App.UITests/PrompterLive.App.UITests.csproj --no-build`
 - `dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.App.Tests/PrompterLive.App.Tests.csproj --filter "FullyQualifiedName~SettingsInteractionTests.AboutSection_RendersInjectedAppVersionMetadata"`
+- `dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.App.Tests/PrompterLive.App.Tests.csproj --filter "FullyQualifiedName~SettingsInteractionTests.AboutSection_RendersInjectedAppVersionMetadata_AndOfficialManagedCodeLinks"`
 - `dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.App.UITests/PrompterLive.App.UITests.csproj --filter "FullyQualifiedName~TeleprompterSettingsFlowTests.TeleprompterAndSettingsScreens_RespondToCoreControls"`
 - `.github/workflows/deploy-github-pages.yml` publish step passes `-p:PrompterLiveBuildNumber=${{ github.run_number }}`
 - `.github/workflows/deploy-github-pages.yml` publishes both the GitHub Release asset and the GitHub Pages artifact from the same release build output

--- a/docs/Features/ReaderRuntime.md
+++ b/docs/Features/ReaderRuntime.md
@@ -11,6 +11,9 @@ The important contracts are:
 - RSVP keeps a five-word context rail on each side, matching `new-design/app.js`.
 - Teleprompter camera stays behind the text as one background layer.
 - Teleprompter word groups stay short enough to avoid run-on lines.
+- Teleprompter preserves TPS word presentation details such as pronunciation guides, inline colors, emotion styling, and speed-derived spacing/timing.
+- Teleprompter pre-centers the next card before it slides in, so block transitions do not jump at the focal line.
+- Teleprompter controls stay readable at rest; they must not fade until they become unusable.
 
 ## Flow
 
@@ -38,11 +41,17 @@ flowchart LR
 - `teleprompter` selects one primary camera device for `#rd-camera`.
 - `teleprompter` does not render overlay camera elements such as `#rd-camera-overlay-*`.
 - `teleprompter` groups words by pauses, sentence endings, clause endings, and short phrase limits.
+- `teleprompter` forwards TPS pronunciation metadata to word-level `title` / `data-pronunciation` attributes.
+- `teleprompter` derives word-level pacing from the compiled TPS duration and carries effective WPM into the DOM for testable parity.
+- `teleprompter` keeps TPS inline colors visible even when a phrase group is active or the active word is highlighted.
 
 ## Verification
 
 - bUnit verifies teleprompter background-camera markup and readable phrase groups.
+- bUnit verifies product-launch TPS modifiers survive into teleprompter word markup, timing, and pronunciation metadata.
 - Core tests verify TPS scripts generate RSVP phrase groups.
+- Core tests verify shorthand inline WPM scopes such as `[180WPM]...[/180WPM]` survive nested tags.
 - Playwright verifies ORP centering and the `security-incident` phrase-aware flow in `learn`.
 - Playwright verifies there is no teleprompter overlay camera box and that phrase groups do not overflow.
 - Playwright verifies the teleprompter camera button attaches and detaches a real synthetic `MediaStream` on the background video layer.
+- Playwright verifies the full `Product Launch` teleprompter scenario, including visible controls, TPS formatting parity, screenshot artifacts, and aligned post-transition playback.

--- a/new-design/settings.html
+++ b/new-design/settings.html
@@ -1240,41 +1240,42 @@
                         </div>
                     </div>
 
-                    <!-- Team -->
+                    <!-- Managed Code -->
                     <div class="set-dest-card open" onclick="toggleDestCard(this)">
                         <div class="set-dest-header">
                             <div class="set-dest-icon" style="background:rgba(196,160,96,.10); color:var(--gold);">
-                                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/></svg>
+                                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 7L9 18l-5-5"/></svg>
                             </div>
                             <div class="set-dest-info">
-                                <span class="set-dest-name">Our Team</span>
-                                <span class="set-dest-account">Built with care from Kyiv 🇺🇦</span>
+                                <span class="set-dest-name">Managed Code</span>
+                                <span class="set-dest-account">Product, design &amp; engineering by Managed Code</span>
                             </div>
                             <svg class="set-dest-chevron" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6,9 12,15 18,9"/></svg>
                         </div>
                         <div class="set-dest-body" onclick="event.stopPropagation()">
+                            <p class="set-card-copy">Everything in Prompter.live is designed, built, and maintained by Managed Code. Use the official links below for the company site, the public GitHub organization, and the live product site.</p>
                             <div class="set-device-fields">
-                                <div class="set-field" style="flex-direction:row;align-items:center;gap:12px;padding:4px 0;">
-                                    <div style="width:36px;height:36px;border-radius:50%;background:linear-gradient(135deg,#C4A060,#8B6A3A);display:flex;align-items:center;justify-content:center;font-size:14px;font-weight:700;color:white;flex-shrink:0;">M</div>
-                                    <div>
-                                        <div style="font-size:13px;font-weight:600;color:var(--t1);">Mykola Kovalenko</div>
-                                        <div style="font-size:11px;color:var(--t4);margin-top:1px;">Founder · Product &amp; Design</div>
+                                <a class="set-about-link set-field set-field-toggle" href="https://www.managed-code.com/" target="_blank" rel="noreferrer">
+                                    <div class="set-about-link-copy">
+                                        <label>Managed Code website</label>
+                                        <span class="set-about-link-meta">Official company website</span>
                                     </div>
-                                </div>
-                                <div class="set-field" style="flex-direction:row;align-items:center;gap:12px;padding:4px 0;">
-                                    <div style="width:36px;height:36px;border-radius:50%;background:linear-gradient(135deg,#60A5FA,#2563EB);display:flex;align-items:center;justify-content:center;font-size:14px;font-weight:700;color:white;flex-shrink:0;">A</div>
-                                    <div>
-                                        <div style="font-size:13px;font-weight:600;color:var(--t1);">Anna Petrenko</div>
-                                        <div style="font-size:11px;color:var(--t4);margin-top:1px;">Lead Engineer</div>
+                                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="var(--t4)" stroke-width="2"><polyline points="9,18 15,12 9,6"/></svg>
+                                </a>
+                                <a class="set-about-link set-field set-field-toggle" href="https://github.com/managedcode" target="_blank" rel="noreferrer">
+                                    <div class="set-about-link-copy">
+                                        <label>Managed Code on GitHub</label>
+                                        <span class="set-about-link-meta">Official GitHub organization</span>
                                     </div>
-                                </div>
-                                <div class="set-field" style="flex-direction:row;align-items:center;gap:12px;padding:4px 0;">
-                                    <div style="width:36px;height:36px;border-radius:50%;background:linear-gradient(135deg,#34D399,#059669);display:flex;align-items:center;justify-content:center;font-size:14px;font-weight:700;color:white;flex-shrink:0;">D</div>
-                                    <div>
-                                        <div style="font-size:13px;font-weight:600;color:var(--t1);">Dmytro Shevchenko</div>
-                                        <div style="font-size:11px;color:var(--t4);margin-top:1px;">Backend &amp; Infrastructure</div>
+                                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="var(--t4)" stroke-width="2"><polyline points="9,18 15,12 9,6"/></svg>
+                                </a>
+                                <a class="set-about-link set-field set-field-toggle" href="https://prompter.managed-code.com/" target="_blank" rel="noreferrer">
+                                    <div class="set-about-link-copy">
+                                        <label>Prompter.live app</label>
+                                        <span class="set-about-link-meta">Live standalone WebAssembly build</span>
                                     </div>
-                                </div>
+                                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="var(--t4)" stroke-width="2"><polyline points="9,18 15,12 9,6"/></svg>
+                                </a>
                             </div>
                         </div>
                     </div>
@@ -1339,22 +1340,27 @@
                         </div>
                         <div class="set-dest-body" onclick="event.stopPropagation()">
                             <div class="set-device-fields">
-                                <div class="set-field set-field-toggle" style="cursor:pointer;" onclick="event.preventDefault()">
-                                    <label style="cursor:pointer;">What's New</label>
+                                <a class="set-about-link set-field set-field-toggle" href="https://github.com/managedcode/PrompterLive" target="_blank" rel="noreferrer">
+                                    <div class="set-about-link-copy">
+                                        <label>PrompterLive repository</label>
+                                        <span class="set-about-link-meta">Source code, docs, and milestones</span>
+                                    </div>
                                     <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="var(--t4)" stroke-width="2"><polyline points="9,18 15,12 9,6"/></svg>
-                                </div>
-                                <div class="set-field set-field-toggle" style="cursor:pointer;" onclick="event.preventDefault()">
-                                    <label style="cursor:pointer;">Help &amp; Documentation</label>
+                                </a>
+                                <a class="set-about-link set-field set-field-toggle" href="https://github.com/managedcode/PrompterLive/releases" target="_blank" rel="noreferrer">
+                                    <div class="set-about-link-copy">
+                                        <label>Release notes</label>
+                                        <span class="set-about-link-meta">Published builds and changelog</span>
+                                    </div>
                                     <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="var(--t4)" stroke-width="2"><polyline points="9,18 15,12 9,6"/></svg>
-                                </div>
-                                <div class="set-field set-field-toggle" style="cursor:pointer;" onclick="event.preventDefault()">
-                                    <label style="cursor:pointer;">Report a Bug</label>
+                                </a>
+                                <a class="set-about-link set-field set-field-toggle" href="https://github.com/managedcode/PrompterLive/issues" target="_blank" rel="noreferrer">
+                                    <div class="set-about-link-copy">
+                                        <label>Report an issue</label>
+                                        <span class="set-about-link-meta">Bug reports and product feedback</span>
+                                    </div>
                                     <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="var(--t4)" stroke-width="2"><polyline points="9,18 15,12 9,6"/></svg>
-                                </div>
-                                <div class="set-field set-field-toggle" style="cursor:pointer;" onclick="event.preventDefault()">
-                                    <label style="cursor:pointer;">Privacy Policy</label>
-                                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="var(--t4)" stroke-width="2"><polyline points="9,18 15,12 9,6"/></svg>
-                                </div>
+                                </a>
                             </div>
                         </div>
                     </div>
@@ -1362,7 +1368,7 @@
                 </div>
 
                 <div style="text-align:center;font-size:12px;color:var(--t4);padding:16px 0 8px;">
-                    Made with care in Ukraine 🇺🇦 · © 2026 Prompter.live
+                    Built and maintained by Managed Code.
                 </div>
 
     </div><!-- /screen -->

--- a/new-design/styles-settings.css
+++ b/new-design/styles-settings.css
@@ -1344,9 +1344,21 @@
     text-decoration: none;
     display: block;
     cursor: pointer;
+    color: inherit;
 }
 .set-about-link:hover .set-dest-header {
     background: none;
+}
+
+.set-about-link-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.set-about-link-meta {
+    color: var(--t4);
+    font-size: 11px;
 }
 
 .set-about-footer {

--- a/new-design/styles-teleprompter.css
+++ b/new-design/styles-teleprompter.css
@@ -219,10 +219,10 @@
 .tps-professional { color: #5B7FFF; }
 
 /* ── TPS Speed Indicators (visual cue for speed tags) ── */
-.tps-xslow { letter-spacing: 1.5px; }
-.tps-slow { letter-spacing: 0.5px; }
-.tps-fast { letter-spacing: -0.3px; }
-.tps-xfast { letter-spacing: -0.5px; opacity: .7; }
+.tps-xslow { letter-spacing: var(--tps-word-letter-spacing, 0.055em); }
+.tps-slow { letter-spacing: var(--tps-word-letter-spacing, 0.028em); }
+.tps-fast { letter-spacing: var(--tps-word-letter-spacing, -0.015em); }
+.tps-xfast { letter-spacing: var(--tps-word-letter-spacing, -0.028em); opacity: .78; }
 
 /* ── TPS Pronunciation guide (subtle tooltip-like) ── */
 .tps-phonetic {
@@ -453,6 +453,23 @@ span.rd-pause.rd-pause-long {
 .rd-g-active > .rd-w.tps-orange:not(.rd-now):not(.rd-read) { color: rgba(255,169,77,.75); }
 .rd-g-active > .rd-w.tps-purple:not(.rd-now):not(.rd-read) { color: rgba(204,93,232,.75); }
 .rd-g-active > .rd-w.tps-cyan:not(.rd-now):not(.rd-read) { color: rgba(102,217,232,.75); }
+.rd-g-active > .rd-w.tps-magenta:not(.rd-now):not(.rd-read) { color: rgba(247,131,172,.75); }
+.rd-g-active > .rd-w.tps-pink:not(.rd-now):not(.rd-read) { color: rgba(250,162,193,.75); }
+.rd-g-active > .rd-w.tps-teal:not(.rd-now):not(.rd-read) { color: rgba(56,217,169,.75); }
+.rd-g-active > .rd-w.tps-white:not(.rd-now):not(.rd-read) { color: rgba(248,249,250,.78); }
+.rd-g-active > .rd-w.tps-gray:not(.rd-now):not(.rd-read) { color: rgba(173,181,189,.72); }
+.rd-g-active > .rd-w.tps-warm:not(.rd-now):not(.rd-read) { color: rgba(255,169,77,.75); }
+.rd-g-active > .rd-w.tps-concerned:not(.rd-now):not(.rd-read) { color: rgba(255,107,107,.75); }
+.rd-g-active > .rd-w.tps-focused:not(.rd-now):not(.rd-read) { color: rgba(81,207,102,.75); }
+.rd-g-active > .rd-w.tps-motivational:not(.rd-now):not(.rd-read) { color: rgba(204,93,232,.75); }
+.rd-g-active > .rd-w.tps-neutral:not(.rd-now):not(.rd-read) { color: rgba(116,192,252,.75); }
+.rd-g-active > .rd-w.tps-urgent:not(.rd-now):not(.rd-read) { color: rgba(255,68,68,.82); }
+.rd-g-active > .rd-w.tps-happy:not(.rd-now):not(.rd-read) { color: rgba(255,224,102,.75); }
+.rd-g-active > .rd-w.tps-excited:not(.rd-now):not(.rd-read) { color: rgba(250,162,193,.75); }
+.rd-g-active > .rd-w.tps-sad:not(.rd-now):not(.rd-read) { color: rgba(123,104,238,.75); }
+.rd-g-active > .rd-w.tps-calm:not(.rd-now):not(.rd-read) { color: rgba(56,217,169,.75); }
+.rd-g-active > .rd-w.tps-energetic:not(.rd-now):not(.rd-read) { color: rgba(255,99,71,.78); }
+.rd-g-active > .rd-w.tps-professional:not(.rd-now):not(.rd-read) { color: rgba(91,127,255,.78); }
 .rd-g-active > .rd-w.tps-emphasis:not(.rd-now):not(.rd-read) { color: rgba(232,213,176,.80); }
 .rd-g-active > .rd-w.tps-highlight:not(.rd-now):not(.rd-read) { background: rgba(255,224,102,.18); }
 
@@ -495,6 +512,23 @@ span.rd-pause.rd-pause-long {
 .rd-w.rd-now.tps-orange { color: #FFA94D; text-shadow: 0 0 40px rgba(255,169,77,.3); }
 .rd-w.rd-now.tps-purple { color: #CC5DE8; text-shadow: 0 0 40px rgba(204,93,232,.3); }
 .rd-w.rd-now.tps-cyan { color: #66D9E8; text-shadow: 0 0 40px rgba(102,217,232,.3); }
+.rd-w.rd-now.tps-magenta { color: #F783AC; text-shadow: 0 0 40px rgba(247,131,172,.3); }
+.rd-w.rd-now.tps-pink { color: #FAA2C1; text-shadow: 0 0 40px rgba(250,162,193,.3); }
+.rd-w.rd-now.tps-teal { color: #38D9A9; text-shadow: 0 0 40px rgba(56,217,169,.3); }
+.rd-w.rd-now.tps-white { color: #F8F9FA; text-shadow: 0 0 40px rgba(248,249,250,.25); }
+.rd-w.rd-now.tps-gray { color: #ADB5BD; text-shadow: 0 0 40px rgba(173,181,189,.25); }
+.rd-w.rd-now.tps-warm { color: #FFA94D; text-shadow: 0 0 40px rgba(255,169,77,.3); }
+.rd-w.rd-now.tps-concerned { color: #FF6B6B; text-shadow: 0 0 40px rgba(255,107,107,.3); }
+.rd-w.rd-now.tps-focused { color: #51CF66; text-shadow: 0 0 40px rgba(81,207,102,.3); }
+.rd-w.rd-now.tps-motivational { color: #CC5DE8; text-shadow: 0 0 40px rgba(204,93,232,.3); }
+.rd-w.rd-now.tps-neutral { color: #74C0FC; text-shadow: 0 0 40px rgba(116,192,252,.3); }
+.rd-w.rd-now.tps-urgent { color: #FF4444; text-shadow: 0 0 40px rgba(255,68,68,.32); }
+.rd-w.rd-now.tps-happy { color: #FFE066; text-shadow: 0 0 40px rgba(255,224,102,.3); }
+.rd-w.rd-now.tps-excited { color: #FAA2C1; text-shadow: 0 0 40px rgba(250,162,193,.3); }
+.rd-w.rd-now.tps-sad { color: #7B68EE; text-shadow: 0 0 40px rgba(123,104,238,.3); }
+.rd-w.rd-now.tps-calm { color: #38D9A9; text-shadow: 0 0 40px rgba(56,217,169,.3); }
+.rd-w.rd-now.tps-energetic { color: #FF6347; text-shadow: 0 0 40px rgba(255,99,71,.3); }
+.rd-w.rd-now.tps-professional { color: #5B7FFF; text-shadow: 0 0 40px rgba(91,127,255,.3); }
 
 /* Active word with emphasis/strong */
 .rd-w.rd-now.tps-emphasis,
@@ -636,10 +670,10 @@ span.rd-pause.rd-pause-long {
     justify-content: space-between;
     z-index: 10;
     pointer-events: none;
-    opacity: .15;
+    opacity: .58;
     transition: opacity .3s;
 }
-.rd-edge-info:hover { opacity: .4; pointer-events: auto; }
+.rd-edge-info:hover { opacity: .82; pointer-events: auto; }
 .rd-edge-section {
     font-size: 10px;
     font-weight: 600;
@@ -651,7 +685,7 @@ span.rd-pause.rd-pause-long {
 .rd-time {
     font-size: 11px;
     font-family: var(--mono);
-    color: rgba(232,213,176,.3);
+    color: rgba(232,213,176,.55);
     white-space: nowrap;
 }
 
@@ -687,15 +721,15 @@ span.rd-pause.rd-pause-long {
     align-items: center;
     gap: 20px;
     padding: 12px 6px;
-    background: rgba(20,18,12,.5);
-    backdrop-filter: blur(12px);
-    border: 1px solid var(--gold-08);
+    background: rgba(20,18,12,.74);
+    backdrop-filter: blur(18px);
+    border: 1px solid var(--gold-14);
     border-radius: 12px;
-    opacity: .2;
+    opacity: .66;
     transition: opacity .4s;
 }
 .rd-sliders:hover {
-    opacity: .75;
+    opacity: .96;
 }
 .rd-slider-group {
     display: flex;
@@ -704,13 +738,13 @@ span.rd-pause.rd-pause-long {
     gap: 6px;
 }
 .rd-slider-icon {
-    color: rgba(232,213,176,.5);
+    color: rgba(232,213,176,.72);
     flex-shrink: 0;
 }
 .rd-slider-val {
     font-size: 9px;
     font-family: var(--mono);
-    color: rgba(232,213,176,.35);
+    color: rgba(232,213,176,.62);
     letter-spacing: 0.5px;
     white-space: nowrap;
 }
@@ -729,7 +763,7 @@ span.rd-pause.rd-pause-long {
 .rd-vslider::-webkit-slider-runnable-track {
     width: 3px;
     height: 100%;
-    background: rgba(232,213,176,.10);
+    background: rgba(232,213,176,.22);
     border-radius: 2px;
 }
 .rd-vslider::-webkit-slider-thumb {
@@ -737,19 +771,19 @@ span.rd-pause.rd-pause-long {
     width: 14px;
     height: 14px;
     border-radius: 50%;
-    background: rgba(232,213,176,.45);
-    border: 2px solid rgba(232,213,176,.15);
+    background: rgba(232,213,176,.78);
+    border: 2px solid rgba(12,10,6,.38);
     margin-left: -5.5px;
     cursor: grab;
     transition: background .2s;
 }
 .rd-vslider::-webkit-slider-thumb:hover {
-    background: rgba(232,213,176,.7);
+    background: rgba(232,213,176,.94);
 }
 .rd-vslider::-moz-range-track {
     width: 3px;
     height: 100%;
-    background: rgba(232,213,176,.10);
+    background: rgba(232,213,176,.22);
     border-radius: 2px;
     border: none;
 }
@@ -757,8 +791,8 @@ span.rd-pause.rd-pause-long {
     width: 14px;
     height: 14px;
     border-radius: 50%;
-    background: rgba(232,213,176,.45);
-    border: 2px solid rgba(232,213,176,.15);
+    background: rgba(232,213,176,.78);
+    border: 2px solid rgba(12,10,6,.38);
     cursor: grab;
 }
 /* Countdown uses no CSS animations — digits appear/disappear instantly */
@@ -774,11 +808,11 @@ span.rd-pause.rd-pause-long {
     align-items: center;
     gap: 8px;
     padding: 6px 12px;
-    background: rgba(20,18,12,.75);
-    backdrop-filter: blur(16px);
-    border: 1px solid var(--gold-08);
+    background: rgba(20,18,12,.84);
+    backdrop-filter: blur(18px);
+    border: 1px solid var(--gold-14);
     border-radius: 16px;
-    opacity: .85;
+    opacity: .97;
     transition: opacity .3s;
 }
 .rd-controls:hover { opacity: 1; }
@@ -800,7 +834,7 @@ span.rd-pause.rd-pause-long {
     height: 36px;
     border-radius: 10px;
     background: transparent;
-    color: rgba(232,213,176,.4);
+    color: rgba(232,213,176,.74);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -809,7 +843,7 @@ span.rd-pause.rd-pause-long {
     transition: all .2s;
 }
 .rd-ctrl-btn:hover {
-    background: var(--gold-08);
+    background: var(--gold-12);
     color: #E8D5B0;
 }
 .rd-ctrl-btn.active {
@@ -819,23 +853,23 @@ span.rd-pause.rd-pause-long {
 .rd-ctrl-sm {
     width: 28px;
     height: 28px;
-    opacity: .5;
+    opacity: .82;
 }
 .rd-ctrl-sm:hover { opacity: 1; }
 .rd-ctrl-play {
     width: 44px;
     height: 44px;
     border-radius: 50%;
-    background: var(--gold-06);
+    background: var(--gold-12);
 }
 .rd-ctrl-play:hover {
-    background: var(--gold-12);
+    background: var(--gold-16);
 }
 
 .rd-ctrl-label {
     font-size: 11px;
     font-family: var(--mono);
-    color: rgba(232,213,176,.35);
+    color: rgba(232,213,176,.62);
     min-width: 24px;
     text-align: center;
     user-select: none;

--- a/src/PrompterLive.App/wwwroot/index.html
+++ b/src/PrompterLive.App/wwwroot/index.html
@@ -59,5 +59,14 @@
             }
         });
     </script>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-Q2SNBFT7MM"></script>
+    <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-Q2SNBFT7MM');
+    </script>
 </body>
 </html>

--- a/src/PrompterLive.Core/Tps/Services/ScriptCompiler.cs
+++ b/src/PrompterLive.Core/Tps/Services/ScriptCompiler.cs
@@ -418,6 +418,12 @@ public class ScriptCompiler
             return true;
         }
 
+        if (TryParseInlineWpmTag(name, out var inlineWpm))
+        {
+            PushScope(scopeStack, lowered, state => state.SpeedOverride = ClampWpm(inlineWpm));
+            return true;
+        }
+
         if (AvailableColors.TryGetValue(lowered, out var colorHex))
         {
             PushScope(scopeStack, lowered, state =>
@@ -729,6 +735,23 @@ public class ScriptCompiler
     }
 
     private static int ClampWpm(int wpm) => Math.Clamp(wpm, MinWpm, MaxWpm);
+
+    private static bool TryParseInlineWpmTag(string name, out int wpm)
+    {
+        const string suffix = "wpm";
+        wpm = 0;
+        if (string.IsNullOrWhiteSpace(name) ||
+            !name.EndsWith(suffix, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return int.TryParse(
+            name[..^suffix.Length],
+            NumberStyles.Integer,
+            CultureInfo.InvariantCulture,
+            out wpm);
+    }
 
     private static string? NormalizeEmotion(string? emotion) =>
         string.IsNullOrWhiteSpace(emotion) ? null : emotion.Trim();

--- a/src/PrompterLive.Shared/Contracts/AboutLinks.cs
+++ b/src/PrompterLive.Shared/Contracts/AboutLinks.cs
@@ -1,0 +1,13 @@
+namespace PrompterLive.Shared.Contracts;
+
+public static class AboutLinks
+{
+    public const string ProductName = "Prompter.live";
+    public const string ManagedCodeName = "Managed Code";
+    public const string ManagedCodeWebsiteUrl = "https://www.managed-code.com/";
+    public const string ManagedCodeGitHubUrl = "https://github.com/managedcode";
+    public const string ProductWebsiteUrl = "https://prompter.managed-code.com/";
+    public const string ProductRepositoryUrl = "https://github.com/managedcode/PrompterLive";
+    public const string ProductReleasesUrl = ProductRepositoryUrl + "/releases";
+    public const string ProductIssuesUrl = ProductRepositoryUrl + "/issues";
+}

--- a/src/PrompterLive.Shared/Contracts/UiTestIds.cs
+++ b/src/PrompterLive.Shared/Contracts/UiTestIds.cs
@@ -172,7 +172,9 @@ public static class UiTestIds
         public const string Back = "teleprompter-back";
         public const string CameraBackground = "teleprompter-camera-layer-primary";
         public const string CameraToggle = "teleprompter-camera-toggle";
+        public const string Controls = "teleprompter-controls";
         public const string EdgeSection = "teleprompter-edge-section";
+        public const string EdgeInfo = "teleprompter-edge-info";
         public const string FocalSlider = "teleprompter-focal-slider";
         public const string FocalGuide = "teleprompter-focal-guide";
         public const string FontDown = "teleprompter-font-down";
@@ -183,6 +185,7 @@ public static class UiTestIds
         public const string PlayToggle = "teleprompter-play-toggle";
         public const string PreviousBlock = "teleprompter-previous-block";
         public const string PreviousWord = "teleprompter-previous-word";
+        public const string Sliders = "teleprompter-sliders";
         public const string Stage = "teleprompter-stage";
         public const string WidthSlider = "teleprompter-width-slider";
 
@@ -201,7 +204,14 @@ public static class UiTestIds
     public static class Settings
     {
         public const string AboutAppCard = "settings-about-app-card";
+        public const string AboutCompanyCard = "settings-about-company-card";
+        public const string AboutCompanyGitHub = "settings-about-company-github";
+        public const string AboutCompanyWebsite = "settings-about-company-website";
         public const string AboutPanel = "settings-about-panel";
+        public const string AboutProductWebsite = "settings-about-product-website";
+        public const string AboutRepositoryLink = "settings-about-repository-link";
+        public const string AboutReleasesLink = "settings-about-releases-link";
+        public const string AboutIssuesLink = "settings-about-issues-link";
         public const string AboutVersion = "settings-about-version";
         public const string AppearancePanel = "settings-appearance-panel";
         public const string AiPanel = "settings-ai-panel";

--- a/src/PrompterLive.Shared/Settings/Components/SettingsAboutSection.razor
+++ b/src/PrompterLive.Shared/Settings/Components/SettingsAboutSection.razor
@@ -4,11 +4,11 @@
          id="set-about"
          style="@DisplayStyle"
          data-testid="@UiTestIds.Settings.AboutPanel">
-    <h3 class="set-section-title">About</h3>
-    <p class="set-section-desc">Prompter.live — professional teleprompter for creators, broadcasters, and public speakers.</p>
+    <h3 class="set-section-title">@AboutSectionTitle</h3>
+    <p class="set-section-desc">@AboutSectionDescription</p>
 
     <div class="set-device-list">
-        <SettingsExpandableCard Title="Prompter.live"
+        <SettingsExpandableCard Title="@AppCardTitle"
                                 Subtitle="@AppCardSubtitle"
                                 SubtitleTestId="@UiTestIds.Settings.AboutVersion"
                                 StatusLabel="@LicensedStatusLabel"
@@ -22,11 +22,11 @@
             </svg>
             <div class="set-device-fields">
                 <div class="set-field set-field-toggle">
-                    <label>Software Updates</label>
-                    <span class="set-dest-status set-dest-ok" style="font-size:12px;">Up to date</span>
+                    <label>@SoftwareUpdatesLabel</label>
+                    <span class="set-dest-status set-dest-ok" style="font-size:12px;">@UpToDateLabel</span>
                 </div>
                 <div class="set-field set-field-toggle">
-                    <label>Check for updates automatically</label>
+                    <label>@AutomaticUpdatesLabel</label>
                     <div class="set-toggle on">
                         <div class="set-toggle-thumb"></div>
                     </div>
@@ -34,32 +34,38 @@
             </div>
         </SettingsExpandableCard>
 
-        <SettingsExpandableCard Title="Our Team"
-                                Subtitle="Built with care from Kyiv"
+        <SettingsExpandableCard Title="@ManagedCodeCardTitle"
+                                Subtitle="@ManagedCodeCardSubtitle"
                                 IconStyle="background:rgba(196,160,96,.10); color:var(--gold);"
-                                IsOpen="@IsCardOpen(TeamCardId)"
-                                OnToggle="@(() => ToggleCard.InvokeAsync(TeamCardId))">
+                                TestId="@UiTestIds.Settings.AboutCompanyCard"
+                                IsOpen="@IsCardOpen(CompanyCardId)"
+                                OnToggle="@(() => ToggleCard.InvokeAsync(CompanyCardId))">
             <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
-                <circle cx="9" cy="7" r="4" />
-                <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
+                <path d="M20 7L9 18l-5-5" />
             </svg>
-            <div class="set-about-team">
-                @foreach (var member in TeamMembers)
+            <p class="set-card-copy">@ManagedCodeCardCopy</p>
+            <div class="set-device-fields">
+                @foreach (var link in CompanyLinks)
                 {
-                    <div class="set-about-member">
-                        <div class="set-about-avatar" style="@member.AvatarStyle">@member.Initials</div>
-                        <div>
-                            <div class="set-about-mname">@member.Name</div>
-                            <div class="set-about-mrole">@member.Role</div>
+                    <a class="set-about-link set-field set-field-toggle"
+                       href="@link.Href"
+                       target="_blank"
+                       rel="noreferrer"
+                       data-testid="@link.TestId">
+                        <div class="set-about-link-copy">
+                            <label>@link.Label</label>
+                            <span class="set-about-link-meta">@link.Description</span>
                         </div>
-                    </div>
+                        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="var(--t4)" stroke-width="2">
+                            <polyline points="9,18 15,12 9,6" />
+                        </svg>
+                    </a>
                 }
             </div>
         </SettingsExpandableCard>
 
-        <SettingsExpandableCard Title="Open Source"
-                                Subtitle="Libraries &amp; licenses"
+        <SettingsExpandableCard Title="@OpenSourceCardTitle"
+                                Subtitle="@OpenSourceCardSubtitle"
                                 IconStyle="background:rgba(99,102,241,.10); color:#818CF8;"
                                 IsOpen="@IsCardOpen(OpenSourceCardId)"
                                 OnToggle="@(() => ToggleCard.InvokeAsync(OpenSourceCardId))">
@@ -81,8 +87,8 @@
             </div>
         </SettingsExpandableCard>
 
-        <SettingsExpandableCard Title="Help &amp; Resources"
-                                Subtitle="Docs, changelog, feedback"
+        <SettingsExpandableCard Title="@ResourcesCardTitle"
+                                Subtitle="@ResourcesCardSubtitle"
                                 IconStyle="background:rgba(59,130,246,.10); color:#60A5FA;"
                                 IsOpen="@IsCardOpen(ResourcesCardId)"
                                 OnToggle="@(() => ToggleCard.InvokeAsync(ResourcesCardId))">
@@ -94,16 +100,23 @@
             <div class="set-device-fields">
                 @foreach (var link in ResourceLinks)
                 {
-                    <div class="set-field set-field-toggle" style="cursor:pointer;">
-                        <label>@link</label>
+                    <a class="set-about-link set-field set-field-toggle"
+                       href="@link.Href"
+                       target="_blank"
+                       rel="noreferrer"
+                       data-testid="@link.TestId">
+                        <div class="set-about-link-copy">
+                            <label>@link.Label</label>
+                            <span class="set-about-link-meta">@link.Description</span>
+                        </div>
                         <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="var(--t4)" stroke-width="2">
                             <polyline points="9,18 15,12 9,6" />
                         </svg>
-                    </div>
+                    </a>
                 }
             </div>
         </SettingsExpandableCard>
     </div>
 
-    <div class="set-about-footer">Made with care in Ukraine · © 2026 Prompter.live</div>
+    <div class="set-about-footer">@FooterText</div>
 </section>

--- a/src/PrompterLive.Shared/Settings/Components/SettingsAboutSection.razor.cs
+++ b/src/PrompterLive.Shared/Settings/Components/SettingsAboutSection.razor.cs
@@ -1,22 +1,48 @@
 using Microsoft.AspNetCore.Components;
+using PrompterLive.Shared.Contracts;
 using PrompterLive.Shared.Settings.Services;
 
 namespace PrompterLive.Shared.Components.Settings;
 
 public partial class SettingsAboutSection
 {
+    private const string AboutSectionTitle = "About";
+    private const string AboutSectionDescription = "Prompter.live is a professional teleprompter for creators, broadcasters, and public speakers.";
+    private const string AppCardTitle = AboutLinks.ProductName;
     private const string AppCardId = "about-app";
+    private const string AutomaticUpdatesLabel = "Check for updates automatically";
+    private const string CompanyCardId = "about-company";
+    private const string FooterText = "Built and maintained by Managed Code.";
     private const string LicensedStatusLabel = "Licensed";
+    private const string ManagedCodeCardCopy = "Everything in Prompter.live is designed, built, and maintained by Managed Code. Use the official links below for the company site, the public GitHub organization, and the live product site.";
+    private const string ManagedCodeCardSubtitle = "Product, design, and engineering by Managed Code";
+    private const string ManagedCodeCardTitle = AboutLinks.ManagedCodeName;
     private const string OpenSourceCardId = "about-open-source";
+    private const string OpenSourceCardSubtitle = "Libraries & licenses";
+    private const string OpenSourceCardTitle = "Open Source";
     private const string ResourcesCardId = "about-resources";
-    private const string TeamCardId = "about-team";
+    private const string ResourcesCardSubtitle = "Live app, releases, and support";
+    private const string ResourcesCardTitle = "Help & Resources";
+    private const string SoftwareUpdatesLabel = "Software Updates";
+    private const string UpToDateLabel = "Up to date";
 
-    private static readonly string[] ResourceLinks =
+    private static readonly AboutLinkItem[] CompanyLinks =
     [
-        "What's New",
-        "Help & Documentation",
-        "Report a Bug",
-        "Privacy Policy"
+        new(
+            UiTestIds.Settings.AboutCompanyWebsite,
+            "Managed Code website",
+            "Official company website",
+            AboutLinks.ManagedCodeWebsiteUrl),
+        new(
+            UiTestIds.Settings.AboutCompanyGitHub,
+            "Managed Code on GitHub",
+            "Official GitHub organization",
+            AboutLinks.ManagedCodeGitHubUrl),
+        new(
+            UiTestIds.Settings.AboutProductWebsite,
+            "Prompter.live app",
+            "Live standalone WebAssembly build",
+            AboutLinks.ProductWebsiteUrl)
     ];
 
     private static readonly AboutItem[] Libraries =
@@ -30,11 +56,23 @@ public partial class SettingsAboutSection
         new("Web Audio API", "High-level audio processing", "W3C")
     ];
 
-    private static readonly TeamMember[] TeamMembers =
+    private static readonly AboutLinkItem[] ResourceLinks =
     [
-        new("M", "Mykola Kovalenko", "Founder · Product & Design", "background:linear-gradient(135deg,#C4A060,#8B6A3A);"),
-        new("A", "Anna Petrenko", "Lead Engineer", "background:linear-gradient(135deg,#60A5FA,#2563EB);"),
-        new("D", "Dmytro Shevchenko", "Backend & Infrastructure", "background:linear-gradient(135deg,#34D399,#059669);")
+        new(
+            UiTestIds.Settings.AboutRepositoryLink,
+            "PrompterLive repository",
+            "Source code, docs, and milestones",
+            AboutLinks.ProductRepositoryUrl),
+        new(
+            UiTestIds.Settings.AboutReleasesLink,
+            "Release notes",
+            "Published builds and changelog",
+            AboutLinks.ProductReleasesUrl),
+        new(
+            UiTestIds.Settings.AboutIssuesLink,
+            "Report an issue",
+            "Bug reports and product feedback",
+            AboutLinks.ProductIssuesUrl)
     ];
 
     [Inject] private IAppVersionProvider AppVersionProvider { get; set; } = null!;
@@ -46,6 +84,5 @@ public partial class SettingsAboutSection
     private string AppCardSubtitle => AppVersionProvider.Current.Subtitle;
 
     private sealed record AboutItem(string Name, string Description, string License);
-
-    private sealed record TeamMember(string Initials, string Name, string Role, string AvatarStyle);
+    private sealed record AboutLinkItem(string TestId, string Label, string Description, string Href);
 }

--- a/src/PrompterLive.Shared/Teleprompter/Pages/TeleprompterPage.ReaderAlignment.cs
+++ b/src/PrompterLive.Shared/Teleprompter/Pages/TeleprompterPage.ReaderAlignment.cs
@@ -18,32 +18,7 @@ public partial class TeleprompterPage
         }
 
         _pendingReaderAlignment = false;
-
-        if (!TryGetAlignmentWordId(out var wordId))
-        {
-            return;
-        }
-
-        var offsetPixels = await ReaderInterop.MeasureClusterOffsetAsync(
-            UiDomIds.Teleprompter.Stage,
-            UiDomIds.Teleprompter.CardText(_activeReaderCardIndex),
-            wordId,
-            _readerFocalPointPercent);
-
-        if (!offsetPixels.HasValue)
-        {
-            return;
-        }
-
-        var nextStyle = BuildReaderCardTextStyleValue(offsetPixels.Value);
-        if (_readerCardTextStyles.TryGetValue(_activeReaderCardIndex, out var currentStyle) &&
-            string.Equals(currentStyle, nextStyle, StringComparison.Ordinal))
-        {
-            return;
-        }
-
-        _readerCardTextStyles[_activeReaderCardIndex] = nextStyle;
-        await InvokeAsync(StateHasChanged);
+        await AlignReaderCardTextAsync(_activeReaderCardIndex, Math.Max(_activeReaderWordIndex, 0), neutralizeCard: false, rerender: true);
     }
 
     private string BuildReaderCardTextStyle(int cardIndex) =>
@@ -59,10 +34,46 @@ public partial class TeleprompterPage
         _pendingReaderAlignment = true;
     }
 
-    private bool TryGetAlignmentWordId(out string wordId)
+    private Task PrepareReaderCardAlignmentAsync(int cardIndex, int wordOrdinal) =>
+        AlignReaderCardTextAsync(cardIndex, wordOrdinal, neutralizeCard: true, rerender: false);
+
+    private async Task AlignReaderCardTextAsync(int cardIndex, int wordOrdinal, bool neutralizeCard, bool rerender)
+    {
+        if (!TryGetAlignmentWordId(cardIndex, wordOrdinal, out var wordId))
+        {
+            return;
+        }
+
+        var offsetPixels = await ReaderInterop.MeasureClusterOffsetAsync(
+            UiDomIds.Teleprompter.Stage,
+            UiDomIds.Teleprompter.CardText(cardIndex),
+            wordId,
+            _readerFocalPointPercent,
+            neutralizeCard);
+
+        if (!offsetPixels.HasValue)
+        {
+            return;
+        }
+
+        var nextStyle = BuildReaderCardTextStyleValue(offsetPixels.Value);
+        if (_readerCardTextStyles.TryGetValue(cardIndex, out var currentStyle) &&
+            string.Equals(currentStyle, nextStyle, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        _readerCardTextStyles[cardIndex] = nextStyle;
+        if (rerender)
+        {
+            await InvokeAsync(StateHasChanged);
+        }
+    }
+
+    private bool TryGetAlignmentWordId(int cardIndex, int wordOrdinal, out string wordId)
     {
         wordId = string.Empty;
-        if (!TryGetAlignmentWordPosition(out var position))
+        if (!TryGetAlignmentWordPosition(cardIndex, wordOrdinal, out var position))
         {
             return false;
         }
@@ -71,16 +82,16 @@ public partial class TeleprompterPage
         return true;
     }
 
-    private bool TryGetAlignmentWordPosition(out (int CardIndex, int ChunkIndex, int WordIndex) position)
+    private bool TryGetAlignmentWordPosition(int cardIndex, int wordOrdinal, out (int CardIndex, int ChunkIndex, int WordIndex) position)
     {
         position = default;
-        if (_activeReaderCardIndex >= _cards.Count)
+        if (cardIndex < 0 || cardIndex >= _cards.Count)
         {
             return false;
         }
 
-        var remainingWords = Math.Max(_activeReaderWordIndex, 0);
-        var chunks = _cards[_activeReaderCardIndex].Chunks;
+        var remainingWords = Math.Max(wordOrdinal, 0);
+        var chunks = _cards[cardIndex].Chunks;
 
         for (var chunkIndex = 0; chunkIndex < chunks.Count; chunkIndex++)
         {
@@ -93,7 +104,7 @@ public partial class TeleprompterPage
             {
                 if (remainingWords == 0)
                 {
-                    position = (_activeReaderCardIndex, chunkIndex, wordIndex);
+                    position = (cardIndex, chunkIndex, wordIndex);
                     return true;
                 }
 

--- a/src/PrompterLive.Shared/Teleprompter/Pages/TeleprompterPage.ReaderContent.cs
+++ b/src/PrompterLive.Shared/Teleprompter/Pages/TeleprompterPage.ReaderContent.cs
@@ -72,7 +72,7 @@ public partial class TeleprompterPage
                     DurationMilliseconds: durationMilliseconds,
                     WidthPercentString: string.Empty,
                     EdgeColor: string.Empty,
-                    Chunks: BuildReaderChunks(words)));
+                    Chunks: BuildReaderChunks(words, targetWpm)));
             }
         }
 
@@ -139,7 +139,7 @@ public partial class TeleprompterPage
         return compiledBlock?.Words ?? compiledSegment?.Words ?? [];
     }
 
-    private static IReadOnlyList<ReaderChunkViewModel> BuildReaderChunks(IEnumerable<CompiledWord> words)
+    private static IReadOnlyList<ReaderChunkViewModel> BuildReaderChunks(IEnumerable<CompiledWord> words, int targetWpm)
     {
         var chunks = new List<ReaderChunkViewModel>();
         var currentGroup = new List<ReaderWordViewModel>();
@@ -179,10 +179,15 @@ public partial class TeleprompterPage
                 currentCharacterCount += 1;
             }
 
+            var effectiveWpm = ResolveEffectiveWpm(word.Metadata, targetWpm);
             currentGroup.Add(new ReaderWordViewModel(
                 Text: word.CleanText,
-                CssClass: BuildReaderWordBaseClass(word.Metadata),
-                DurationMs: Math.Max(MinimumReaderWordDurationMilliseconds, (int)Math.Round(word.DisplayDuration.TotalMilliseconds))));
+                CssClass: BuildReaderWordBaseClass(word.Metadata, targetWpm),
+                DurationMs: Math.Max(MinimumReaderWordDurationMilliseconds, (int)Math.Round(word.DisplayDuration.TotalMilliseconds)),
+                Style: BuildReaderWordStyle(word.Metadata, targetWpm, effectiveWpm),
+                Title: BuildReaderWordTitle(word.Metadata, targetWpm, effectiveWpm),
+                PronunciationGuide: string.IsNullOrWhiteSpace(word.Metadata?.PronunciationGuide) ? null : word.Metadata.PronunciationGuide.Trim(),
+                EffectiveWpm: effectiveWpm));
 
             if (ShouldEndReaderGroup(word.CleanText, currentGroup.Count, currentCharacterCount))
             {
@@ -221,7 +226,7 @@ public partial class TeleprompterPage
         currentGroup.Clear();
     }
 
-    private static string BuildReaderWordBaseClass(WordMetadata? metadata)
+    private static string BuildReaderWordBaseClass(WordMetadata? metadata, int targetWpm)
     {
         if (metadata is null)
         {
@@ -247,28 +252,23 @@ public partial class TeleprompterPage
             classes.Add(emotionClass);
         }
 
-        if (metadata.SpeedOverride.HasValue)
+        var effectiveWpm = ResolveEffectiveWpm(metadata, targetWpm);
+        var speedRatio = effectiveWpm / (double)Math.Max(MinimumReaderReferenceWpm, targetWpm);
+        if (speedRatio <= 0.65d)
         {
-            classes.Add(metadata.SpeedOverride.Value >= 175 ? "tps-fast" : "tps-slow");
+            classes.Add("tps-xslow");
         }
-        else if (metadata.SpeedMultiplier.HasValue)
+        else if (speedRatio < 0.95d)
         {
-            if (metadata.SpeedMultiplier <= 0.65f)
-            {
-                classes.Add("tps-xslow");
-            }
-            else if (metadata.SpeedMultiplier < 1f)
-            {
-                classes.Add("tps-slow");
-            }
-            else if (metadata.SpeedMultiplier >= 1.45f)
-            {
-                classes.Add("tps-xfast");
-            }
-            else if (metadata.SpeedMultiplier > 1f)
-            {
-                classes.Add("tps-fast");
-            }
+            classes.Add("tps-slow");
+        }
+        else if (speedRatio >= 1.45d)
+        {
+            classes.Add("tps-xfast");
+        }
+        else if (speedRatio > 1.05d)
+        {
+            classes.Add("tps-fast");
         }
 
         if (!string.IsNullOrWhiteSpace(metadata.PronunciationGuide))
@@ -349,6 +349,7 @@ public partial class TeleprompterPage
             "#ec4899" or "pink" => $"{prefix}-pink",
             "#14b8a6" or "teal" => $"{prefix}-teal",
             "#ffffff" or "white" => $"{prefix}-white",
+            "#111827" or "black" => $"{prefix}-gray",
             "#6b7280" or "gray" => $"{prefix}-gray",
             "#ffeb3b" or "highlight" => $"{prefix}-highlight",
             _ => string.Empty

--- a/src/PrompterLive.Shared/Teleprompter/Pages/TeleprompterPage.ReaderModels.cs
+++ b/src/PrompterLive.Shared/Teleprompter/Pages/TeleprompterPage.ReaderModels.cs
@@ -55,7 +55,15 @@ public partial class TeleprompterPage
 
     private sealed record ReaderPauseViewModel(int DurationMs, string CssClass) : ReaderChunkViewModel;
 
-    private sealed record ReaderWordViewModel(string Text, string CssClass, int DurationMs, int PauseAfterMs = 0);
+    private sealed record ReaderWordViewModel(
+        string Text,
+        string CssClass,
+        int DurationMs,
+        int PauseAfterMs = 0,
+        string? Style = null,
+        string? Title = null,
+        string? PronunciationGuide = null,
+        int? EffectiveWpm = null);
 
     private sealed record ReaderCameraLayerViewModel(
         string ElementId,

--- a/src/PrompterLive.Shared/Teleprompter/Pages/TeleprompterPage.ReaderPlayback.cs
+++ b/src/PrompterLive.Shared/Teleprompter/Pages/TeleprompterPage.ReaderPlayback.cs
@@ -126,6 +126,7 @@ public partial class TeleprompterPage
 
             await Task.Delay(ReaderFirstWordDelayMilliseconds, cancellationToken);
 
+            await PrepareReaderCardAlignmentAsync(_activeReaderCardIndex, 0);
             _activeReaderWordIndex = 0;
             UpdateReaderDisplayState();
             _isReaderPlaying = true;
@@ -192,6 +193,7 @@ public partial class TeleprompterPage
 
         if (direction < 0 && _activeReaderWordIndex > 1)
         {
+            await PrepareReaderCardAlignmentAsync(_activeReaderCardIndex, 0);
             _activeReaderWordIndex = 0;
             UpdateReaderDisplayState();
 
@@ -325,6 +327,7 @@ public partial class TeleprompterPage
 
     private async Task AdvanceToCardAsync(int nextCardIndex, CancellationToken cancellationToken)
     {
+        await PrepareReaderCardAlignmentAsync(nextCardIndex, 0);
         _activeReaderCardIndex = nextCardIndex;
         _activeReaderWordIndex = -1;
         UpdateReaderDisplayState();

--- a/src/PrompterLive.Shared/Teleprompter/Pages/TeleprompterPage.ReaderWordStyling.cs
+++ b/src/PrompterLive.Shared/Teleprompter/Pages/TeleprompterPage.ReaderWordStyling.cs
@@ -1,0 +1,91 @@
+using System.Globalization;
+using PrompterLive.Core.Models.CompiledScript;
+
+namespace PrompterLive.Shared.Pages;
+
+public partial class TeleprompterPage
+{
+    private const double FastLetterSpacingDeadZoneRatio = 0.05d;
+    private const double MaximumFastLetterSpacingEm = -0.028d;
+    private const int MinimumReaderReferenceWpm = 60;
+    private const string PronunciationTitlePrefix = "Pronunciation: ";
+    private const string ReaderSpeedTitlePrefix = "Speed: ";
+    private const string ReaderWordLetterSpacingVariable = "--tps-word-letter-spacing";
+    private const double SlowLetterSpacingRangeRatio = 0.4d;
+    private const double FastLetterSpacingRangeRatio = 0.55d;
+    private const double MaximumSlowLetterSpacingEm = 0.058d;
+    private const string WpmSuffix = " WPM";
+
+    private static string? BuildReaderWordStyle(WordMetadata? metadata, int targetWpm, int effectiveWpm)
+    {
+        if (metadata is null)
+        {
+            return null;
+        }
+
+        var referenceWpm = Math.Max(MinimumReaderReferenceWpm, targetWpm);
+        var speedRatio = effectiveWpm / (double)referenceWpm;
+        if (Math.Abs(speedRatio - 1d) <= FastLetterSpacingDeadZoneRatio)
+        {
+            return null;
+        }
+
+        var letterSpacingEm = speedRatio < 1d
+            ? Math.Min(
+                MaximumSlowLetterSpacingEm,
+                MaximumSlowLetterSpacingEm * (1d - speedRatio) / SlowLetterSpacingRangeRatio)
+            : -Math.Min(
+                Math.Abs(MaximumFastLetterSpacingEm),
+                Math.Abs(MaximumFastLetterSpacingEm) * (speedRatio - 1d) / FastLetterSpacingRangeRatio);
+
+        if (Math.Abs(letterSpacingEm) < 0.001d)
+        {
+            return null;
+        }
+
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"{ReaderWordLetterSpacingVariable}:{letterSpacingEm:0.###}em;");
+    }
+
+    private static string? BuildReaderWordTitle(WordMetadata? metadata, int targetWpm, int effectiveWpm)
+    {
+        if (metadata is null)
+        {
+            return null;
+        }
+
+        var titleParts = new List<string>();
+        if (!string.IsNullOrWhiteSpace(metadata.PronunciationGuide))
+        {
+            titleParts.Add(PronunciationTitlePrefix + metadata.PronunciationGuide.Trim());
+        }
+
+        if (effectiveWpm != targetWpm)
+        {
+            titleParts.Add(ReaderSpeedTitlePrefix + effectiveWpm.ToString(CultureInfo.InvariantCulture) + WpmSuffix);
+        }
+
+        return titleParts.Count == 0
+            ? null
+            : string.Join(" · ", titleParts);
+    }
+
+    private static int ResolveEffectiveWpm(WordMetadata? metadata, int targetWpm)
+    {
+        var referenceWpm = Math.Max(MinimumReaderReferenceWpm, targetWpm);
+        if (metadata?.SpeedOverride is int speedOverride)
+        {
+            return Math.Max(MinimumReaderReferenceWpm, speedOverride);
+        }
+
+        if (metadata?.SpeedMultiplier is float speedMultiplier && speedMultiplier > 0f)
+        {
+            return Math.Max(
+                MinimumReaderReferenceWpm,
+                (int)Math.Round(referenceWpm * speedMultiplier, MidpointRounding.AwayFromZero));
+        }
+
+        return referenceWpm;
+    }
+}

--- a/src/PrompterLive.Shared/Teleprompter/Pages/TeleprompterPage.razor
+++ b/src/PrompterLive.Shared/Teleprompter/Pages/TeleprompterPage.razor
@@ -31,7 +31,7 @@
 
             <div class="@BuildCountdownCssClass()" id="@UiDomIds.Teleprompter.Countdown">@BuildCountdownLabel()</div>
 
-            <div class="rd-sliders">
+            <div class="rd-sliders" data-testid="@UiTestIds.Teleprompter.Sliders">
                 <div class="rd-slider-group">
                     <svg class="rd-slider-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="3" y1="12" x2="21" y2="12" /><line x1="3" y1="8" x2="3" y2="16" /><line x1="21" y1="8" x2="21" y2="16" /></svg>
                     <input type="range"
@@ -107,6 +107,10 @@
                                                           id="@UiDomIds.Teleprompter.CardWord(entry.index, chunkIndex, wordIndex)"
                                                           data-ms="@word.DurationMs"
                                                           data-pause-ms="@word.PauseAfterMs"
+                                                          data-effective-wpm="@word.EffectiveWpm"
+                                                          data-pronunciation="@word.PronunciationGuide"
+                                                          title="@word.Title"
+                                                          style="@word.Style"
                                                           data-testid="@UiTestIds.Teleprompter.CardWord(entry.index, chunkIndex, wordIndex)">@word.Text</span>
                                                     @if (wordIndex < group.Words.Count - 1)
                                                     {
@@ -145,7 +149,7 @@
                     }
                 </div>
             </div>
-            <div class="rd-edge-info">
+            <div class="rd-edge-info" data-testid="@UiTestIds.Teleprompter.EdgeInfo">
                 <span class="rd-edge-section" data-testid="@UiTestIds.Teleprompter.EdgeSection">@_edgeSectionLabel</span>
                 <span class="rd-time"
                       id="@UiDomIds.Teleprompter.Time"
@@ -153,7 +157,7 @@
                       data-total-ms="@_totalDurationMilliseconds">@BuildElapsedLabel()</span>
             </div>
 
-            <div class="rd-controls">
+            <div class="rd-controls" data-testid="@UiTestIds.Teleprompter.Controls">
                 <div class="rd-ctrl-group">
                     <button class="rd-ctrl-btn" @onclick="DecreaseReaderFontSizeAsync" title="Smaller text" data-testid="@UiTestIds.Teleprompter.FontDown">
                         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="5" y1="12" x2="19" y2="12" /></svg>

--- a/src/PrompterLive.Shared/Teleprompter/Services/TeleprompterReaderInterop.cs
+++ b/src/PrompterLive.Shared/Teleprompter/Services/TeleprompterReaderInterop.cs
@@ -10,11 +10,13 @@ public sealed class TeleprompterReaderInterop(IJSRuntime jsRuntime)
         string stageId,
         string textId,
         string targetWordId,
-        int focalPointPercent) =>
+        int focalPointPercent,
+        bool neutralizeCard = false) =>
         _jsRuntime.InvokeAsync<double?>(
             TeleprompterReaderInteropMethodNames.MeasureClusterOffset,
             stageId,
             textId,
             targetWordId,
-            focalPointPercent);
+            focalPointPercent,
+            neutralizeCard);
 }

--- a/src/PrompterLive.Shared/wwwroot/design/modules/reader/00-shell.css
+++ b/src/PrompterLive.Shared/wwwroot/design/modules/reader/00-shell.css
@@ -222,8 +222,7 @@
 .tps-professional { color: #5B7FFF; }
 
 /* ── TPS Speed Indicators (visual cue for speed tags) ── */
-.tps-xslow { letter-spacing: 1.5px; }
-.tps-slow { letter-spacing: 0.5px; }
-.tps-fast { letter-spacing: -0.3px; }
-.tps-xfast { letter-spacing: -0.5px; opacity: .7; }
-
+.tps-xslow { letter-spacing: var(--tps-word-letter-spacing, 0.055em); }
+.tps-slow { letter-spacing: var(--tps-word-letter-spacing, 0.028em); }
+.tps-fast { letter-spacing: var(--tps-word-letter-spacing, -0.015em); }
+.tps-xfast { letter-spacing: var(--tps-word-letter-spacing, -0.028em); opacity: .78; }

--- a/src/PrompterLive.Shared/wwwroot/design/modules/reader/10-reading-states.css
+++ b/src/PrompterLive.Shared/wwwroot/design/modules/reader/10-reading-states.css
@@ -230,6 +230,23 @@ span.rd-pause.rd-pause-long {
 .rd-g-active > .rd-w.tps-orange:not(.rd-now):not(.rd-read) { color: rgba(255,169,77,.75); }
 .rd-g-active > .rd-w.tps-purple:not(.rd-now):not(.rd-read) { color: rgba(204,93,232,.75); }
 .rd-g-active > .rd-w.tps-cyan:not(.rd-now):not(.rd-read) { color: rgba(102,217,232,.75); }
+.rd-g-active > .rd-w.tps-magenta:not(.rd-now):not(.rd-read) { color: rgba(247,131,172,.75); }
+.rd-g-active > .rd-w.tps-pink:not(.rd-now):not(.rd-read) { color: rgba(250,162,193,.75); }
+.rd-g-active > .rd-w.tps-teal:not(.rd-now):not(.rd-read) { color: rgba(56,217,169,.75); }
+.rd-g-active > .rd-w.tps-white:not(.rd-now):not(.rd-read) { color: rgba(248,249,250,.78); }
+.rd-g-active > .rd-w.tps-gray:not(.rd-now):not(.rd-read) { color: rgba(173,181,189,.72); }
+.rd-g-active > .rd-w.tps-warm:not(.rd-now):not(.rd-read) { color: rgba(255,169,77,.75); }
+.rd-g-active > .rd-w.tps-concerned:not(.rd-now):not(.rd-read) { color: rgba(255,107,107,.75); }
+.rd-g-active > .rd-w.tps-focused:not(.rd-now):not(.rd-read) { color: rgba(81,207,102,.75); }
+.rd-g-active > .rd-w.tps-motivational:not(.rd-now):not(.rd-read) { color: rgba(204,93,232,.75); }
+.rd-g-active > .rd-w.tps-neutral:not(.rd-now):not(.rd-read) { color: rgba(116,192,252,.75); }
+.rd-g-active > .rd-w.tps-urgent:not(.rd-now):not(.rd-read) { color: rgba(255,68,68,.82); }
+.rd-g-active > .rd-w.tps-happy:not(.rd-now):not(.rd-read) { color: rgba(255,224,102,.75); }
+.rd-g-active > .rd-w.tps-excited:not(.rd-now):not(.rd-read) { color: rgba(250,162,193,.75); }
+.rd-g-active > .rd-w.tps-sad:not(.rd-now):not(.rd-read) { color: rgba(123,104,238,.75); }
+.rd-g-active > .rd-w.tps-calm:not(.rd-now):not(.rd-read) { color: rgba(56,217,169,.75); }
+.rd-g-active > .rd-w.tps-energetic:not(.rd-now):not(.rd-read) { color: rgba(255,99,71,.78); }
+.rd-g-active > .rd-w.tps-professional:not(.rd-now):not(.rd-read) { color: rgba(91,127,255,.78); }
 .rd-g-active > .rd-w.tps-emphasis:not(.rd-now):not(.rd-read) { color: rgba(232,213,176,.80); }
 .rd-g-active > .rd-w.tps-highlight:not(.rd-now):not(.rd-read) { background: rgba(255,224,102,.18); }
 
@@ -272,6 +289,23 @@ span.rd-pause.rd-pause-long {
 .rd-w.rd-now.tps-orange { color: #FFA94D; text-shadow: 0 0 40px rgba(255,169,77,.3); }
 .rd-w.rd-now.tps-purple { color: #CC5DE8; text-shadow: 0 0 40px rgba(204,93,232,.3); }
 .rd-w.rd-now.tps-cyan { color: #66D9E8; text-shadow: 0 0 40px rgba(102,217,232,.3); }
+.rd-w.rd-now.tps-magenta { color: #F783AC; text-shadow: 0 0 40px rgba(247,131,172,.3); }
+.rd-w.rd-now.tps-pink { color: #FAA2C1; text-shadow: 0 0 40px rgba(250,162,193,.3); }
+.rd-w.rd-now.tps-teal { color: #38D9A9; text-shadow: 0 0 40px rgba(56,217,169,.3); }
+.rd-w.rd-now.tps-white { color: #F8F9FA; text-shadow: 0 0 40px rgba(248,249,250,.25); }
+.rd-w.rd-now.tps-gray { color: #ADB5BD; text-shadow: 0 0 40px rgba(173,181,189,.25); }
+.rd-w.rd-now.tps-warm { color: #FFA94D; text-shadow: 0 0 40px rgba(255,169,77,.3); }
+.rd-w.rd-now.tps-concerned { color: #FF6B6B; text-shadow: 0 0 40px rgba(255,107,107,.3); }
+.rd-w.rd-now.tps-focused { color: #51CF66; text-shadow: 0 0 40px rgba(81,207,102,.3); }
+.rd-w.rd-now.tps-motivational { color: #CC5DE8; text-shadow: 0 0 40px rgba(204,93,232,.3); }
+.rd-w.rd-now.tps-neutral { color: #74C0FC; text-shadow: 0 0 40px rgba(116,192,252,.3); }
+.rd-w.rd-now.tps-urgent { color: #FF4444; text-shadow: 0 0 40px rgba(255,68,68,.32); }
+.rd-w.rd-now.tps-happy { color: #FFE066; text-shadow: 0 0 40px rgba(255,224,102,.3); }
+.rd-w.rd-now.tps-excited { color: #FAA2C1; text-shadow: 0 0 40px rgba(250,162,193,.3); }
+.rd-w.rd-now.tps-sad { color: #7B68EE; text-shadow: 0 0 40px rgba(123,104,238,.3); }
+.rd-w.rd-now.tps-calm { color: #38D9A9; text-shadow: 0 0 40px rgba(56,217,169,.3); }
+.rd-w.rd-now.tps-energetic { color: #FF6347; text-shadow: 0 0 40px rgba(255,99,71,.3); }
+.rd-w.rd-now.tps-professional { color: #5B7FFF; text-shadow: 0 0 40px rgba(91,127,255,.3); }
 
 /* Active word with emphasis/strong */
 .rd-w.rd-now.tps-emphasis,
@@ -279,5 +313,4 @@ span.rd-pause.rd-pause-long {
     color: var(--accent);
     text-shadow: 0 0 50px rgba(232,130,92,.3);
 }
-
 

--- a/src/PrompterLive.Shared/wwwroot/design/modules/reader/20-controls.css
+++ b/src/PrompterLive.Shared/wwwroot/design/modules/reader/20-controls.css
@@ -122,10 +122,10 @@
     justify-content: space-between;
     z-index: 10;
     pointer-events: none;
-    opacity: .15;
+    opacity: .58;
     transition: opacity .3s;
 }
-.rd-edge-info:hover { opacity: .4; pointer-events: auto; }
+.rd-edge-info:hover { opacity: .82; pointer-events: auto; }
 .rd-edge-section {
     font-size: 10px;
     font-weight: 600;
@@ -137,7 +137,7 @@
 .rd-time {
     font-size: 11px;
     font-family: var(--mono);
-    color: rgba(232,213,176,.3);
+    color: rgba(232,213,176,.55);
     white-space: nowrap;
 }
 
@@ -173,15 +173,15 @@
     align-items: center;
     gap: 20px;
     padding: 12px 6px;
-    background: rgba(20,18,12,.5);
-    backdrop-filter: blur(12px);
-    border: 1px solid var(--gold-08);
+    background: rgba(20,18,12,.74);
+    backdrop-filter: blur(18px);
+    border: 1px solid var(--gold-14);
     border-radius: 12px;
-    opacity: .2;
+    opacity: .66;
     transition: opacity .4s;
 }
 .rd-sliders:hover {
-    opacity: .75;
+    opacity: .96;
 }
 .rd-slider-group {
     display: flex;
@@ -190,13 +190,13 @@
     gap: 6px;
 }
 .rd-slider-icon {
-    color: rgba(232,213,176,.5);
+    color: rgba(232,213,176,.72);
     flex-shrink: 0;
 }
 .rd-slider-val {
     font-size: 9px;
     font-family: var(--mono);
-    color: rgba(232,213,176,.35);
+    color: rgba(232,213,176,.62);
     letter-spacing: 0.5px;
     white-space: nowrap;
 }
@@ -215,7 +215,7 @@
 .rd-vslider::-webkit-slider-runnable-track {
     width: 3px;
     height: 100%;
-    background: rgba(232,213,176,.10);
+    background: rgba(232,213,176,.22);
     border-radius: 2px;
 }
 .rd-vslider::-webkit-slider-thumb {
@@ -223,19 +223,19 @@
     width: 14px;
     height: 14px;
     border-radius: 50%;
-    background: rgba(232,213,176,.45);
-    border: 2px solid rgba(232,213,176,.15);
+    background: rgba(232,213,176,.78);
+    border: 2px solid rgba(12,10,6,.38);
     margin-left: -5.5px;
     cursor: grab;
     transition: background .2s;
 }
 .rd-vslider::-webkit-slider-thumb:hover {
-    background: rgba(232,213,176,.7);
+    background: rgba(232,213,176,.94);
 }
 .rd-vslider::-moz-range-track {
     width: 3px;
     height: 100%;
-    background: rgba(232,213,176,.10);
+    background: rgba(232,213,176,.22);
     border-radius: 2px;
     border: none;
 }
@@ -243,8 +243,8 @@
     width: 14px;
     height: 14px;
     border-radius: 50%;
-    background: rgba(232,213,176,.45);
-    border: 2px solid rgba(232,213,176,.15);
+    background: rgba(232,213,176,.78);
+    border: 2px solid rgba(12,10,6,.38);
     cursor: grab;
 }
 /* Countdown uses no CSS animations — digits appear/disappear instantly */
@@ -260,11 +260,11 @@
     align-items: center;
     gap: 8px;
     padding: 6px 12px;
-    background: rgba(20,18,12,.75);
-    backdrop-filter: blur(16px);
-    border: 1px solid var(--gold-08);
+    background: rgba(20,18,12,.84);
+    backdrop-filter: blur(18px);
+    border: 1px solid var(--gold-14);
     border-radius: 16px;
-    opacity: .85;
+    opacity: .97;
     transition: opacity .3s;
 }
 .rd-controls:hover { opacity: 1; }
@@ -286,7 +286,7 @@
     height: 36px;
     border-radius: 10px;
     background: transparent;
-    color: rgba(232,213,176,.4);
+    color: rgba(232,213,176,.74);
     display: flex;
     align-items: center;
     justify-content: center;
@@ -295,7 +295,7 @@
     transition: all .2s;
 }
 .rd-ctrl-btn:hover {
-    background: var(--gold-08);
+    background: var(--gold-12);
     color: #E8D5B0;
 }
 .rd-ctrl-btn.active {
@@ -305,23 +305,23 @@
 .rd-ctrl-sm {
     width: 28px;
     height: 28px;
-    opacity: .5;
+    opacity: .82;
 }
 .rd-ctrl-sm:hover { opacity: 1; }
 .rd-ctrl-play {
     width: 44px;
     height: 44px;
     border-radius: 50%;
-    background: var(--gold-06);
+    background: var(--gold-12);
 }
 .rd-ctrl-play:hover {
-    background: var(--gold-12);
+    background: var(--gold-16);
 }
 
 .rd-ctrl-label {
     font-size: 11px;
     font-family: var(--mono);
-    color: rgba(232,213,176,.35);
+    color: rgba(232,213,176,.62);
     min-width: 24px;
     text-align: center;
     user-select: none;
@@ -359,4 +359,3 @@ body::before {
     z-index: 9999;
     mix-blend-mode: overlay;
 }
-

--- a/src/PrompterLive.Shared/wwwroot/design/modules/settings/20-reference.css
+++ b/src/PrompterLive.Shared/wwwroot/design/modules/settings/20-reference.css
@@ -758,6 +758,32 @@
     margin-bottom: 0;
 }
 
+.set-about-link {
+    color: inherit;
+    text-decoration: none;
+    transition: background .12s ease, border-color .12s ease;
+}
+
+.set-about-link:hover {
+    background: rgba(196, 160, 96, .06);
+}
+
+.set-about-link-copy {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.set-about-link-copy label {
+    cursor: pointer;
+}
+
+.set-about-link-meta {
+    color: var(--t4);
+    font-size: 11px;
+}
+
 .set-about-team {
     display: flex;
     flex-direction: column;

--- a/src/PrompterLive.Shared/wwwroot/teleprompter/teleprompter-reader.js
+++ b/src/PrompterLive.Shared/wwwroot/teleprompter/teleprompter-reader.js
@@ -2,10 +2,15 @@
     const teleprompterReaderNamespace = "TeleprompterReaderInterop";
 
     window[teleprompterReaderNamespace] = {
-        measureClusterOffset(stageId, textId, targetWordId, focalPointPercent) {
+        measureClusterOffset(stageId, textId, targetWordId, focalPointPercent, neutralizeCard) {
             const stage = document.getElementById(stageId);
             const text = document.getElementById(textId);
             const targetWord = document.getElementById(targetWordId);
+            const card = Boolean(neutralizeCard)
+                ? targetWord instanceof HTMLElement
+                    ? targetWord.closest(".rd-card")
+                    : null
+                : null;
 
             if (!(stage instanceof HTMLElement) || !(text instanceof HTMLElement) || !(targetWord instanceof HTMLElement)) {
                 return null;
@@ -13,6 +18,15 @@
 
             const previousTransition = text.style.transition;
             const previousTransform = text.style.transform;
+            const previousCardOpacity = card instanceof HTMLElement ? card.style.opacity : "";
+            const previousCardTransition = card instanceof HTMLElement ? card.style.transition : "";
+            const previousCardTransform = card instanceof HTMLElement ? card.style.transform : "";
+
+            if (card instanceof HTMLElement) {
+                card.style.opacity = "0";
+                card.style.transition = "none";
+                card.style.transform = "translateY(0)";
+            }
 
             text.style.transition = "none";
             text.style.transform = "none";
@@ -25,6 +39,11 @@
 
             text.style.transform = previousTransform;
             text.style.transition = previousTransition;
+            if (card instanceof HTMLElement) {
+                card.style.opacity = previousCardOpacity;
+                card.style.transition = previousCardTransition;
+                card.style.transform = previousCardTransform;
+            }
 
             return Number.isFinite(offset) ? offset : null;
         }

--- a/tests/PrompterLive.App.Tests/Settings/SettingsInteractionTests.cs
+++ b/tests/PrompterLive.App.Tests/Settings/SettingsInteractionTests.cs
@@ -11,6 +11,9 @@ namespace PrompterLive.App.Tests;
 
 public sealed class SettingsInteractionTests : BunitContext
 {
+    private const string FakeEngineerName = "Anna Petrenko";
+    private const string FakeFounderName = "Mykola Kovalenko";
+    private const string FakeInfrastructureName = "Dmytro Shevchenko";
     private const string ReaderSettingsKey = "prompterlive.reader";
     private const string SceneSettingsKey = "prompterlive.scene";
 
@@ -136,7 +139,7 @@ public sealed class SettingsInteractionTests : BunitContext
     }
 
     [Fact]
-    public void AboutSection_RendersInjectedAppVersionMetadata()
+    public void AboutSection_RendersInjectedAppVersionMetadata_AndOfficialManagedCodeLinks()
     {
         var cut = Render<SettingsPage>();
 
@@ -150,6 +153,28 @@ public sealed class SettingsInteractionTests : BunitContext
                 AppTestData.About.VersionSubtitle,
                 cut.FindByTestId(UiTestIds.Settings.AboutVersion).TextContent.Trim());
             Assert.NotNull(cut.FindByTestId(UiTestIds.Settings.AboutAppCard));
+            Assert.NotNull(cut.FindByTestId(UiTestIds.Settings.AboutCompanyCard));
+            Assert.Equal(
+                AboutLinks.ManagedCodeWebsiteUrl,
+                cut.FindByTestId(UiTestIds.Settings.AboutCompanyWebsite).GetAttribute("href"));
+            Assert.Equal(
+                AboutLinks.ManagedCodeGitHubUrl,
+                cut.FindByTestId(UiTestIds.Settings.AboutCompanyGitHub).GetAttribute("href"));
+            Assert.Equal(
+                AboutLinks.ProductWebsiteUrl,
+                cut.FindByTestId(UiTestIds.Settings.AboutProductWebsite).GetAttribute("href"));
+            Assert.Equal(
+                AboutLinks.ProductRepositoryUrl,
+                cut.FindByTestId(UiTestIds.Settings.AboutRepositoryLink).GetAttribute("href"));
+            Assert.Equal(
+                AboutLinks.ProductReleasesUrl,
+                cut.FindByTestId(UiTestIds.Settings.AboutReleasesLink).GetAttribute("href"));
+            Assert.Equal(
+                AboutLinks.ProductIssuesUrl,
+                cut.FindByTestId(UiTestIds.Settings.AboutIssuesLink).GetAttribute("href"));
+            Assert.DoesNotContain(FakeFounderName, cut.Markup, StringComparison.Ordinal);
+            Assert.DoesNotContain(FakeEngineerName, cut.Markup, StringComparison.Ordinal);
+            Assert.DoesNotContain(FakeInfrastructureName, cut.Markup, StringComparison.Ordinal);
         });
     }
 

--- a/tests/PrompterLive.App.Tests/Support/AppTestData.cs
+++ b/tests/PrompterLive.App.Tests/Support/AppTestData.cs
@@ -43,6 +43,7 @@ internal static class AppTestData
         public static string EditorQuantum => AppRoutes.EditorWithId(Scripts.QuantumId);
         public static string GoLiveDemo => AppRoutes.GoLiveWithId(Scripts.DemoId);
         public static string LearnQuantum => AppRoutes.LearnWithId(Scripts.QuantumId);
+        public static string TeleprompterDemo => AppRoutes.TeleprompterWithId(Scripts.DemoId);
         public static string TeleprompterQuantum => AppRoutes.TeleprompterWithId(Scripts.QuantumId);
         public static string TeleprompterSecurityIncident => AppRoutes.TeleprompterWithId(Scripts.SecurityIncidentId);
         public const string Settings = AppRoutes.Settings;

--- a/tests/PrompterLive.App.Tests/Teleprompter/TeleprompterFidelityTests.cs
+++ b/tests/PrompterLive.App.Tests/Teleprompter/TeleprompterFidelityTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Bunit;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
@@ -9,6 +10,16 @@ namespace PrompterLive.App.Tests;
 
 public sealed class TeleprompterFidelityTests : BunitContext
 {
+    private const int BenefitsCardIndex = 5;
+    private const int ClosingCardIndex = 7;
+    private const int InspirationCardIndex = 6;
+    private const int StatisticsCardIndex = 2;
+    private const string FastWord = "Full";
+    private const string PurpleWord = "focus";
+    private const string SlowWord = "elephant";
+    private const string TeleprompterWord = "teleprompter";
+    private const string VisionWord = "vision";
+
     [Fact]
     public void TeleprompterPage_UsesReferenceSizedReaderGroupsForSecurityIncident()
     {
@@ -38,4 +49,47 @@ public sealed class TeleprompterFidelityTests : BunitContext
             Assert.DoesNotContain("rd-camera-overlay-", cut.Markup, StringComparison.Ordinal);
         });
     }
+
+    [Fact]
+    public void TeleprompterPage_PropagatesTpsWordFormattingTimingAndPronunciationMetadata()
+    {
+        var harness = TestHarnessFactory.Create(this);
+        Services.GetRequiredService<NavigationManager>()
+            .NavigateTo(AppTestData.Routes.TeleprompterDemo);
+        var cut = Render<TeleprompterPage>();
+
+        cut.WaitForAssertion(() =>
+        {
+            var slowWord = FindReaderWordByText(cut, StatisticsCardIndex, SlowWord);
+            var fastWord = FindReaderWordByText(cut, BenefitsCardIndex, FastWord);
+            var visionWord = FindReaderWordByText(cut, InspirationCardIndex, VisionWord);
+            var teleprompterWord = FindReaderWordByText(cut, ClosingCardIndex, TeleprompterWord);
+            var purpleWord = FindReaderWordByText(cut, InspirationCardIndex, PurpleWord);
+
+            Assert.Contains("tps-xslow", slowWord.ClassName, StringComparison.Ordinal);
+            Assert.Contains("--tps-word-letter-spacing:", slowWord.GetAttribute("style"), StringComparison.Ordinal);
+            Assert.Contains("Speed: 90 WPM", slowWord.GetAttribute("title"), StringComparison.Ordinal);
+
+            Assert.Contains("tps-xfast", fastWord.ClassName, StringComparison.Ordinal);
+            Assert.Contains("--tps-word-letter-spacing:-", fastWord.GetAttribute("style"), StringComparison.Ordinal);
+            Assert.True(GetWordDurationMilliseconds(slowWord) > GetWordDurationMilliseconds(fastWord));
+
+            Assert.Contains("tps-purple", purpleWord.ClassName, StringComparison.Ordinal);
+
+            Assert.Equal("ˈviʒən", visionWord.GetAttribute("data-pronunciation"));
+            Assert.Contains("Pronunciation: ˈviʒən", visionWord.GetAttribute("title"), StringComparison.Ordinal);
+
+            Assert.Equal("TELE-promp-ter", teleprompterWord.GetAttribute("data-pronunciation"));
+            Assert.Equal("180", teleprompterWord.GetAttribute("data-effective-wpm"));
+            Assert.Contains("Speed: 180 WPM", teleprompterWord.GetAttribute("title"), StringComparison.Ordinal);
+        });
+    }
+
+    private static AngleSharp.Dom.IElement FindReaderWordByText(IRenderedComponent<TeleprompterPage> cut, int cardIndex, string text) =>
+        cut.FindByTestId(UiTestIds.Teleprompter.CardText(cardIndex))
+            .QuerySelectorAll(".rd-w")
+            .Single(element => string.Equals(element.TextContent.Trim(), text, StringComparison.Ordinal));
+
+    private static int GetWordDurationMilliseconds(AngleSharp.Dom.IElement word) =>
+        int.Parse(word.GetAttribute("data-ms")!, CultureInfo.InvariantCulture);
 }

--- a/tests/PrompterLive.App.UITests/Support/BrowserTestConstants.Scenarios.cs
+++ b/tests/PrompterLive.App.UITests/Support/BrowserTestConstants.Scenarios.cs
@@ -32,6 +32,14 @@ internal static partial class BrowserTestConstants
         public const string TeleprompterFocal = "35";
     }
 
+    public static class TeleprompterFullFlow
+    {
+        public const string Name = "teleprompter-product-launch";
+        public const string InitialStep = "01-product-launch-initial";
+        public const string PlaybackStep = "02-product-launch-playback";
+        public const string TransitionStep = "03-product-launch-transition";
+    }
+
     public static class NewScriptWorkflow
     {
         public const string Name = "new-script-workflow";

--- a/tests/PrompterLive.App.UITests/Support/BrowserTestConstants.ScreenFlows.cs
+++ b/tests/PrompterLive.App.UITests/Support/BrowserTestConstants.ScreenFlows.cs
@@ -32,11 +32,23 @@ internal static partial class BrowserTestConstants
 
     public static class TeleprompterFlow
     {
+        public const double ControlsMinimumOpacity = 0.9;
         public const string OpeningBlock = "Opening Block";
         public const string OpeningLine = "Good morning everyone";
         public const string CollapsedOpeningLine = "Goodmorningeveryone";
+        public const double EdgeInfoMinimumOpacity = 0.5;
+        public const string FastWord = "Full";
         public const string FontScaleAfterIncrease = "40";
+        public const string NeutralWord = "Good";
         public const string WidthAfterChange = "900";
+        public const string ProductLaunchPurpleWord = "focus";
+        public const string ProductLaunchSlowWord = "elephant";
+        public const string ProductLaunchTeleprompterWord = "teleprompter";
+        public const string ProductLaunchTeleprompterPronunciation = "TELE-promp-ter";
+        public const string ProductLaunchTeleprompterWpm = "180";
+        public const string ProductLaunchVisionPronunciation = "ˈviʒən";
+        public const string ProductLaunchVisionWord = "vision";
+        public const double SlidersMinimumOpacity = 0.6;
         public const string CameraRoleAttribute = "data-camera-role";
         public const string CameraDeviceIdAttribute = "data-camera-device-id";
         public const string CameraAutostartAttribute = "data-camera-autostart";

--- a/tests/PrompterLive.App.UITests/Teleprompter/TeleprompterFullFlowTests.cs
+++ b/tests/PrompterLive.App.UITests/Teleprompter/TeleprompterFullFlowTests.cs
@@ -1,0 +1,208 @@
+using System.Globalization;
+using PrompterLive.Shared.Contracts;
+using static Microsoft.Playwright.Assertions;
+
+namespace PrompterLive.App.UITests;
+
+public sealed class TeleprompterFullFlowTests(StandaloneAppFixture fixture) : IClassFixture<StandaloneAppFixture>
+{
+    private const int BenefitsCardIndex = 5;
+    private const int ClosingCardIndex = 7;
+    private const int OpeningCardIndex = 0;
+    private const int StatisticsCardIndex = 2;
+    private const int InspirationCardIndex = 6;
+
+    [Fact]
+    public async Task TeleprompterProductLaunch_FullTpsScenario_CapturesArtifactsAndKeepsAlignment()
+    {
+        var page = await fixture.NewPageAsync();
+
+        try
+        {
+            UiScenarioArtifacts.ResetScenario(BrowserTestConstants.TeleprompterFullFlow.Name);
+            await page.GotoAsync(BrowserTestConstants.Routes.TeleprompterDemo);
+            await Expect(page.GetByTestId(UiTestIds.Teleprompter.Page))
+                .ToBeVisibleAsync(new() { Timeout = BrowserTestConstants.Timing.ExtendedVisibleTimeoutMs });
+
+            await AssertProductLaunchTpsRenderingAsync(page);
+            await UiScenarioArtifacts.CapturePageAsync(
+                page,
+                BrowserTestConstants.TeleprompterFullFlow.Name,
+                BrowserTestConstants.TeleprompterFullFlow.InitialStep);
+
+            var playToggle = page.GetByTestId(UiTestIds.Teleprompter.PlayToggle);
+            await playToggle.ClickAsync();
+            await Expect(playToggle.Locator(BrowserTestConstants.Teleprompter.PauseToggleIconSelector))
+                .ToBeVisibleAsync(new() { Timeout = BrowserTestConstants.Timing.ReaderPlaybackReadyTimeoutMs });
+            await UiScenarioArtifacts.CapturePageAsync(
+                page,
+                BrowserTestConstants.TeleprompterFullFlow.Name,
+                BrowserTestConstants.TeleprompterFullFlow.PlaybackStep);
+
+            await Expect(page.Locator($"#{UiDomIds.Teleprompter.BlockIndicator}"))
+                .ToHaveTextAsync(
+                    BrowserTestConstants.Regexes.ReaderSecondBlockIndicator,
+                    new() { Timeout = BrowserTestConstants.Timing.ReaderAutomaticTransitionTimeoutMs });
+
+            await AssertCurrentActiveWordAlignedAsync(page);
+            await UiScenarioArtifacts.CapturePageAsync(
+                page,
+                BrowserTestConstants.TeleprompterFullFlow.Name,
+                BrowserTestConstants.TeleprompterFullFlow.TransitionStep);
+        }
+        finally
+        {
+            await page.Context.CloseAsync();
+        }
+    }
+
+    private static async Task AssertProductLaunchTpsRenderingAsync(Microsoft.Playwright.IPage page)
+    {
+        var neutralWord = await GetWordProbeAsync(page, OpeningCardIndex, BrowserTestConstants.TeleprompterFlow.NeutralWord);
+        var slowWord = await GetWordProbeAsync(page, StatisticsCardIndex, BrowserTestConstants.TeleprompterFlow.ProductLaunchSlowWord);
+        var fastWord = await GetWordProbeAsync(page, BenefitsCardIndex, BrowserTestConstants.TeleprompterFlow.FastWord);
+        var visionWord = await GetWordProbeAsync(page, InspirationCardIndex, BrowserTestConstants.TeleprompterFlow.ProductLaunchVisionWord);
+        var purpleWord = await GetWordProbeAsync(page, InspirationCardIndex, BrowserTestConstants.TeleprompterFlow.ProductLaunchPurpleWord);
+        var teleprompterWord = await GetWordProbeAsync(page, ClosingCardIndex, BrowserTestConstants.TeleprompterFlow.ProductLaunchTeleprompterWord);
+
+        Assert.Contains("tps-xslow", slowWord.Classes, StringComparison.Ordinal);
+        Assert.Contains("tps-xfast", fastWord.Classes, StringComparison.Ordinal);
+        Assert.Contains("tps-purple", purpleWord.Classes, StringComparison.Ordinal);
+
+        Assert.Equal(BrowserTestConstants.TeleprompterFlow.ProductLaunchVisionPronunciation, visionWord.Pronunciation);
+        Assert.Contains(
+            BrowserTestConstants.TeleprompterFlow.ProductLaunchVisionPronunciation,
+            visionWord.Title,
+            StringComparison.Ordinal);
+
+        Assert.Equal(BrowserTestConstants.TeleprompterFlow.ProductLaunchTeleprompterPronunciation, teleprompterWord.Pronunciation);
+        Assert.Equal(BrowserTestConstants.TeleprompterFlow.ProductLaunchTeleprompterWpm, teleprompterWord.EffectiveWpm);
+        Assert.Contains(
+            BrowserTestConstants.TeleprompterFlow.ProductLaunchTeleprompterWpm,
+            teleprompterWord.Title,
+            StringComparison.Ordinal);
+
+        Assert.True(ParseMilliseconds(slowWord.DurationMs) > ParseMilliseconds(fastWord.DurationMs));
+        Assert.True(ParsePixels(slowWord.LetterSpacing) > ParsePixels(neutralWord.LetterSpacing));
+        Assert.True(ParsePixels(fastWord.LetterSpacing) < ParsePixels(neutralWord.LetterSpacing));
+    }
+
+    private static async Task AssertCurrentActiveWordAlignedAsync(Microsoft.Playwright.IPage page)
+    {
+        var activeWordTestId = string.Empty;
+        var attemptCount = BrowserTestConstants.Teleprompter.AlignmentTimeoutMs /
+            BrowserTestConstants.Teleprompter.AlignmentPollDelayMs;
+
+        for (var attempt = 0; attempt < attemptCount; attempt++)
+        {
+            activeWordTestId = await page.GetByTestId(UiTestIds.Teleprompter.Page).EvaluateAsync<string>(
+                """
+                element => element.querySelector('.rd-card-active .rd-w.rd-now')?.getAttribute('data-testid') ?? ''
+                """);
+
+            if (!string.IsNullOrWhiteSpace(activeWordTestId))
+            {
+                break;
+            }
+
+            await page.WaitForTimeoutAsync(BrowserTestConstants.Teleprompter.AlignmentPollDelayMs);
+        }
+
+        Assert.False(string.IsNullOrWhiteSpace(activeWordTestId));
+        await AssertGuideAlignmentAsync(
+            page,
+            page.GetByTestId(UiTestIds.Teleprompter.FocalGuide),
+            page.GetByTestId(activeWordTestId));
+    }
+
+    private static async Task AssertGuideAlignmentAsync(
+        Microsoft.Playwright.IPage page,
+        Microsoft.Playwright.ILocator focalGuide,
+        Microsoft.Playwright.ILocator word)
+    {
+        var attemptCount = BrowserTestConstants.Teleprompter.AlignmentTimeoutMs /
+            BrowserTestConstants.Teleprompter.AlignmentPollDelayMs;
+        var lastDelta = double.MaxValue;
+
+        for (var attempt = 0; attempt < attemptCount; attempt++)
+        {
+            lastDelta = await MeasureVerticalCenterDeltaAsync(focalGuide, word);
+            if (Math.Abs(lastDelta) <= BrowserTestConstants.Teleprompter.AlignmentTolerancePx)
+            {
+                return;
+            }
+
+            await page.WaitForTimeoutAsync(BrowserTestConstants.Teleprompter.AlignmentPollDelayMs);
+        }
+
+        Assert.InRange(Math.Abs(lastDelta), 0, BrowserTestConstants.Teleprompter.AlignmentTolerancePx);
+    }
+
+    private static async Task<double> MeasureVerticalCenterDeltaAsync(
+        Microsoft.Playwright.ILocator focalGuide,
+        Microsoft.Playwright.ILocator word)
+    {
+        var focalGuideBox = await focalGuide.BoundingBoxAsync();
+        var wordBox = await word.BoundingBoxAsync();
+
+        Assert.NotNull(focalGuideBox);
+        Assert.NotNull(wordBox);
+
+        return (focalGuideBox.Y + (focalGuideBox.Height / 2d)) -
+            (wordBox.Y + (wordBox.Height / 2d));
+    }
+
+    private static async Task<ReaderWordProbe> GetWordProbeAsync(Microsoft.Playwright.IPage page, int cardIndex, string wordText)
+    {
+        var probe = await page.GetByTestId(UiTestIds.Teleprompter.CardText(cardIndex)).EvaluateAsync<ReaderWordProbe>(
+            """
+            (element, expectedWord) => {
+                const word = Array.from(element.querySelectorAll('.rd-w'))
+                    .find(node => node.textContent?.trim() === expectedWord);
+
+                if (!(word instanceof HTMLElement)) {
+                    return null;
+                }
+
+                const computed = window.getComputedStyle(word);
+                return {
+                    classes: word.className,
+                    style: word.getAttribute('style') ?? '',
+                    title: word.getAttribute('title') ?? '',
+                    pronunciation: word.getAttribute('data-pronunciation') ?? '',
+                    effectiveWpm: word.getAttribute('data-effective-wpm') ?? '',
+                    durationMs: word.getAttribute('data-ms') ?? '',
+                    letterSpacing: computed.letterSpacing ?? ''
+                };
+            }
+            """,
+            wordText);
+
+        Assert.NotNull(probe);
+        return probe!;
+    }
+
+    private static double ParsePixels(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value) || string.Equals(value, "normal", StringComparison.Ordinal))
+        {
+            return 0d;
+        }
+
+        return double.Parse(value.Replace("px", string.Empty, StringComparison.Ordinal), CultureInfo.InvariantCulture);
+    }
+
+    private static int ParseMilliseconds(string value) =>
+        int.Parse(value, CultureInfo.InvariantCulture);
+
+    private sealed class ReaderWordProbe
+    {
+        public string Classes { get; set; } = string.Empty;
+        public string Style { get; set; } = string.Empty;
+        public string Title { get; set; } = string.Empty;
+        public string Pronunciation { get; set; } = string.Empty;
+        public string EffectiveWpm { get; set; } = string.Empty;
+        public string DurationMs { get; set; } = string.Empty;
+        public string LetterSpacing { get; set; } = string.Empty;
+    }
+}

--- a/tests/PrompterLive.App.UITests/Teleprompter/TeleprompterSettingsFlowTests.cs
+++ b/tests/PrompterLive.App.UITests/Teleprompter/TeleprompterSettingsFlowTests.cs
@@ -37,14 +37,17 @@ public sealed class TeleprompterSettingsFlowTests(StandaloneAppFixture fixture) 
     {
         await page.GotoAsync(BrowserTestConstants.Routes.TeleprompterDemo);
         await Expect(page.GetByTestId(UiTestIds.Teleprompter.Page)).ToBeVisibleAsync(new() { Timeout = BrowserTestConstants.Timing.ExtendedVisibleTimeoutMs });
-        await Expect(page.GetByTestId(UiTestIds.Teleprompter.EdgeSection)).ToContainTextAsync("Opening Block");
-        await Expect(page.GetByTestId(UiTestIds.Teleprompter.CardText(0))).ToContainTextAsync("Good morning everyone");
-        await Expect(page.GetByTestId(UiTestIds.Teleprompter.CardText(0))).Not.ToContainTextAsync("Goodmorningeveryone");
-        await Expect(page.Locator($"#{UiDomIds.Teleprompter.Camera}")).ToHaveAttributeAsync("data-camera-autostart", BrowserTestConstants.Regexes.CameraAutoStart);
+        await Expect(page.GetByTestId(UiTestIds.Teleprompter.EdgeSection)).ToContainTextAsync(BrowserTestConstants.TeleprompterFlow.OpeningBlock);
+        await Expect(page.GetByTestId(UiTestIds.Teleprompter.CardText(0))).ToContainTextAsync(BrowserTestConstants.TeleprompterFlow.OpeningLine);
+        await Expect(page.GetByTestId(UiTestIds.Teleprompter.CardText(0))).Not.ToContainTextAsync(BrowserTestConstants.TeleprompterFlow.CollapsedOpeningLine);
+        await Expect(page.Locator($"#{UiDomIds.Teleprompter.Camera}")).ToHaveAttributeAsync(
+            BrowserTestConstants.TeleprompterFlow.CameraAutostartAttribute,
+            BrowserTestConstants.Regexes.CameraAutoStart);
         await Expect(page.Locator($"#{UiDomIds.Teleprompter.CameraOverlay(1)}")).ToHaveCountAsync(0);
+        await AssertTeleprompterChromeVisibilityAsync(page);
 
         await page.GetByTestId(UiTestIds.Teleprompter.FontUp).ClickAsync();
-        await Expect(page.Locator($"#{UiDomIds.Teleprompter.FontLabel}")).ToHaveTextAsync("40");
+        await Expect(page.Locator($"#{UiDomIds.Teleprompter.FontLabel}")).ToHaveTextAsync(BrowserTestConstants.TeleprompterFlow.FontScaleAfterIncrease);
 
         var cameraToggle = page.GetByTestId(UiTestIds.Teleprompter.CameraToggle);
         var cameraWasActive = await HasActiveClassAsync(cameraToggle);
@@ -59,8 +62,8 @@ public sealed class TeleprompterSettingsFlowTests(StandaloneAppFixture fixture) 
             await Expect(cameraToggle).ToHaveClassAsync(BrowserTestConstants.Regexes.ActiveClass);
         }
 
-        await page.GetByTestId(UiTestIds.Teleprompter.WidthSlider).EvaluateAsync("element => { element.value = '900'; element.dispatchEvent(new Event('input', { bubbles: true })); }");
-        await Expect(page.Locator($"#{UiDomIds.Teleprompter.WidthValue}")).ToHaveTextAsync("900");
+        await page.GetByTestId(UiTestIds.Teleprompter.WidthSlider).EvaluateAsync(BrowserTestConstants.TeleprompterFlow.WidthInputScript);
+        await Expect(page.Locator($"#{UiDomIds.Teleprompter.WidthValue}")).ToHaveTextAsync(BrowserTestConstants.TeleprompterFlow.WidthAfterChange);
 
         var playToggle = page.GetByTestId(UiTestIds.Teleprompter.PlayToggle);
         await playToggle.ClickAsync();
@@ -177,7 +180,13 @@ public sealed class TeleprompterSettingsFlowTests(StandaloneAppFixture fixture) 
         await page.GetByTestId(UiTestIds.Settings.NavAbout).ClickAsync();
         await Expect(page.GetByTestId(UiTestIds.Settings.AboutPanel)).ToBeVisibleAsync();
         await Expect(page.GetByTestId(UiTestIds.Settings.AboutAppCard)).ToBeVisibleAsync();
+        await Expect(page.GetByTestId(UiTestIds.Settings.AboutCompanyCard)).ToBeVisibleAsync();
         await Expect(page.GetByTestId(UiTestIds.Settings.AboutVersion)).ToHaveTextAsync(BrowserTestConstants.Regexes.SettingsAboutVersion);
+        await Expect(page.GetByTestId(UiTestIds.Settings.AboutCompanyWebsite)).ToHaveAttributeAsync("href", AboutLinks.ManagedCodeWebsiteUrl);
+        await Expect(page.GetByTestId(UiTestIds.Settings.AboutCompanyGitHub)).ToHaveAttributeAsync("href", AboutLinks.ManagedCodeGitHubUrl);
+        await Expect(page.GetByTestId(UiTestIds.Settings.AboutRepositoryLink)).ToHaveAttributeAsync("href", AboutLinks.ProductRepositoryUrl);
+        await Expect(page.GetByTestId(UiTestIds.Settings.AboutReleasesLink)).ToHaveAttributeAsync("href", AboutLinks.ProductReleasesUrl);
+        await Expect(page.GetByTestId(UiTestIds.Settings.AboutIssuesLink)).ToHaveAttributeAsync("href", AboutLinks.ProductIssuesUrl);
     }
 
     private static async Task<bool> ToggleReaderCameraAsync(Microsoft.Playwright.IPage page)
@@ -205,11 +214,26 @@ public sealed class TeleprompterSettingsFlowTests(StandaloneAppFixture fixture) 
         .Split(BrowserTestConstants.Html.ClassSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
         .Contains(BrowserTestConstants.Css.ActiveClass, StringComparer.Ordinal);
 
+    private static async Task AssertTeleprompterChromeVisibilityAsync(Microsoft.Playwright.IPage page)
+    {
+        var controlsOpacity = await GetOpacityAsync(page.GetByTestId(UiTestIds.Teleprompter.Controls));
+        var slidersOpacity = await GetOpacityAsync(page.GetByTestId(UiTestIds.Teleprompter.Sliders));
+        var edgeInfoOpacity = await GetOpacityAsync(page.GetByTestId(UiTestIds.Teleprompter.EdgeInfo));
+
+        Assert.True(controlsOpacity >= BrowserTestConstants.TeleprompterFlow.ControlsMinimumOpacity);
+        Assert.True(slidersOpacity >= BrowserTestConstants.TeleprompterFlow.SlidersMinimumOpacity);
+        Assert.True(edgeInfoOpacity >= BrowserTestConstants.TeleprompterFlow.EdgeInfoMinimumOpacity);
+    }
+
     private static void AssertDimensionStable(double before, double after) =>
         Assert.InRange(
             Math.Abs(before - after),
             0,
             BrowserTestConstants.SettingsFlow.NavItemLayoutTolerancePx);
+
+    private static Task<double> GetOpacityAsync(Microsoft.Playwright.ILocator locator) =>
+        locator.EvaluateAsync<double>(
+            "element => Number.parseFloat(window.getComputedStyle(element).opacity)");
 
     private static async Task<LayoutBounds> GetRequiredBoundingBoxAsync(Microsoft.Playwright.ILocator locator) =>
         await locator.EvaluateAsync<LayoutBounds>(

--- a/tests/PrompterLive.Core.Tests/Tps/TpsRoundTripTests.cs
+++ b/tests/PrompterLive.Core.Tests/Tps/TpsRoundTripTests.cs
@@ -45,4 +45,33 @@ public sealed class TpsRoundTripTests
         Assert.Equal("p", split.OrpChar);
         Assert.Equal("rompter", split.PostORP);
     }
+
+    [Fact]
+    public async Task CompileAsync_PreservesInlineWpmScopesAcrossNestedPronunciationTags()
+    {
+        var parser = new TpsParser();
+        var compiler = new ScriptCompiler();
+        const string source = """
+        ---
+        title: "Inline speed"
+        base_wpm: 140
+        ---
+
+        ## [Call to Action|140WPM|motivational]
+
+        ### [Closing Block|140WPM|energetic]
+
+        [180WPM]Join us in building the future of [pronunciation:TELE-promp-ter]teleprompter[/pronunciation] technology.[/180WPM]
+        """;
+
+        var document = await parser.ParseAsync(source);
+        var compiled = await compiler.CompileAsync(document);
+        var compiledWord = compiled.Segments
+            .SelectMany(segment => segment.Blocks)
+            .SelectMany(block => block.Words)
+            .Single(word => string.Equals(word.CleanText, "teleprompter", StringComparison.Ordinal));
+
+        Assert.Equal(180, compiledWord.Metadata.SpeedOverride);
+        Assert.Equal("TELE-promp-ter", compiledWord.Metadata.PronunciationGuide);
+    }
 }


### PR DESCRIPTION
## Summary
- replace invented About roster with factual Managed Code and official GitHub/product links
- align teleprompter playback and controls with the design reference
- propagate TPS word-level timing, pronunciation, color/emotion, and speed cues into the teleprompter
- add regression coverage across core, bUnit, and Playwright

## Verification
- dotnet build PrompterLive.slnx -warnaserror
- dotnet test tests/PrompterLive.Core.Tests/PrompterLive.Core.Tests.csproj
- dotnet test tests/PrompterLive.App.Tests/PrompterLive.App.Tests.csproj
- dotnet test tests/PrompterLive.App.UITests/PrompterLive.App.UITests.csproj --no-build
- dotnet test PrompterLive.slnx
- dotnet test PrompterLive.slnx --collect:"XPlat Code Coverage"
- dotnet format PrompterLive.slnx