### PR TITLE
Add browser cloud storage provider integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -296,6 +296,7 @@ Repo-specific design rules:
 - Keep UI routes in shared route constants and keep `data-testid` names in shared UI contract constants.
 - Keep UI flow logic, keyboard shortcuts, DOM ids/selectors, and reusable UI constants in C#/Blazor contracts whenever the platform allows it; use JS only for unavoidable browser API interop or DOM access that Blazor cannot own directly.
 - Prefer deleting JS files entirely when they only hold product UI behavior or duplicated constants; JS modules may exist only as thin bridges to browser APIs or external JS SDKs, with the owning workflow and state kept in C#/Blazor.
+- For standalone cloud-storage integrations, persist provider keys, tokens, and connection metadata in browser `localStorage`; do not introduce server-side secret storage for runtime auth in this app shape.
 - Third-party runtime JavaScript SDKs MUST be sourced only from explicitly pinned GitHub Release tags and assets, copied into the repo, bundled locally with their runtime dependencies, and never loaded from CDNs, package registries, `latest` endpoints, or ad-hoc remote downloads at app runtime.
 - Repo-owned manifests, scripts, workflows, and project files that track third-party runtime JavaScript SDKs MUST point to concrete GitHub release versions and asset URLs, never floating references.
 - Any vendored runtime JavaScript SDK that tracks an upstream GitHub repo MUST have an automated watcher job that checks new GitHub releases and opens a repo issue describing the required update when a newer release appears.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,16 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="Azure.Identity" Version="1.20.0" />
     <PackageVersion Include="bunit" Version="2.6.2" />
     <PackageVersion Include="coverlet.collector" Version="8.0.1" />
+    <PackageVersion Include="ManagedCode.Storage.Browser" Version="10.0.4" />
+    <PackageVersion Include="ManagedCode.Storage.CloudKit" Version="10.0.4" />
+    <PackageVersion Include="ManagedCode.Storage.Dropbox" Version="10.0.4" />
+    <PackageVersion Include="ManagedCode.Storage.Gcp" Version="10.0.4" />
+    <PackageVersion Include="ManagedCode.Storage.GoogleDrive" Version="10.0.4" />
+    <PackageVersion Include="ManagedCode.Storage.OneDrive" Version="10.0.4" />
+    <PackageVersion Include="ManagedCode.Storage.VirtualFileSystem" Version="10.0.4" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="10.0.5" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.5" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.5" />

--- a/cloud-storage-vfs-integration.plan.md
+++ b/cloud-storage-vfs-integration.plan.md
@@ -1,0 +1,198 @@
+# Cloud Storage VFS Integration Plan
+
+## Task Goal
+
+Integrate `ManagedCode.Storage.Browser` plus `ManagedCode.Storage.VirtualFileSystem` for cloud-import/export and future browser-local blob workflows, add runtime-configurable cloud provider connections in Settings for Browser, CloudKit, Dropbox, Google Cloud Storage, Google Drive, and OneDrive, persist provider credentials in browser `localStorage`, and enable import/export of scripts and app settings through those providers without regressing the primary editor/library runtime flows. Record the architectural decision in an ADR before the task is closed.
+
+## Scope
+
+### In Scope
+
+- Add the required `ManagedCode.Storage.*` packages and wire the Storage library into the Blazor WASM host.
+- Introduce a storage abstraction for cloud/import-export and browser-local blob workflows built on `ManagedCode.Storage.Browser` and `IVirtualFileSystem`, while preserving a stable primary runtime store for scripts and folders.
+- Add Settings UI and state for the requested providers:
+  - `ManagedCode.Storage.Browser`
+  - `ManagedCode.Storage.CloudKit`
+  - `ManagedCode.Storage.Dropbox`
+  - `ManagedCode.Storage.Google`
+  - `ManagedCode.Storage.GoogleDrive`
+  - `ManagedCode.Storage.OneDrive`
+  - `ManagedCode.Storage.VirtualFileSystem`
+- Persist provider connection credentials and metadata in browser `localStorage`.
+- Implement import/export flows for scripts and settings through the configured providers.
+- Add automated coverage for the new storage/runtime contracts, Settings UI, and at least one real browser flow through Settings.
+- Write an ADR that documents the local-browser-plus-cloud storage direction and its trade-offs.
+
+### Out Of Scope
+
+- Uploading or archiving recorded video streams.
+- Server-side secret storage, backend APIs, or hosted sync services.
+- End-user OAuth popup or redirect flows beyond fields and provider wiring; user-supplied credentials/tokens remain the auth source for this task.
+- Reworking unrelated Library, Editor, Teleprompter, or Go Live UI beyond storage-backed behavior needed by this change.
+
+## Constraints And Risks
+
+- The app must remain browser-only WASM; no backend may be introduced to support cloud storage.
+- Browser `localStorage` is the canonical store for provider keys/tokens/connection metadata in this runtime shape, even though that increases client-side credential exposure; the ADR must document that risk explicitly.
+- Settings and Library flows already depend on stable `data-testid` contracts; any new cloud actions must add production-owned test ids instead of brittle selectors.
+- `ManagedCode.Storage.Browser` uses IndexedDB/OPFS, so the browser-suite acceptance tests must continue to self-host and run without manual setup.
+- Cloud providers have heterogeneous credential models; the runtime service must validate missing required fields safely and surface clear diagnostics instead of crashing the page.
+- `ManagedCode.Storage.VirtualFileSystem` metadata updates are provider-dependent; this task should keep file layout simple and avoid over-relying on metadata-only directory semantics.
+
+## Testing Methodology
+
+- Use core/component tests to lock down:
+  - browser-local script/settings persistence through the new storage-backed services
+  - provider credential persistence in browser `localStorage`
+  - import/export orchestration for scripts and settings
+  - Settings UI rendering and state transitions for provider cards and actions
+- Use Playwright to verify:
+  - Settings Cloud section exposes provider controls and persisted values
+  - provider credentials survive reload via `localStorage`
+  - script/settings export and import round-trips through the browser-backed local storage provider
+  - screenshot artifacts land under `output/playwright/`
+- Quality bar:
+  - new storage services covered by automated tests with meaningful success and failure assertions
+  - browser Settings flow green with real clicks and persisted state
+  - repo build/test/format/coverage remain green
+
+## Ordered Plan
+
+- [x] Step 1. Establish the exact baseline for the affected solution areas.
+  - Read the current browser repositories, Settings Cloud UI, storage keys/method names, and app DI registration.
+  - Run the relevant baseline commands in order:
+    - `dotnet build /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx -warnaserror`
+    - `dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.Core.Tests/PrompterLive.Core.Tests.csproj`
+    - `dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.App.Tests/PrompterLive.App.Tests.csproj`
+    - `dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.App.UITests/PrompterLive.App.UITests.csproj --no-build`
+  - Verification before moving on:
+    - Record any pre-existing failures below with symptoms and intended handling.
+    - Confirm the current Settings Cloud section is still only stub content before refactoring.
+
+- [x] Step 2. Add the Storage package dependencies and runtime wiring.
+  - Update `Directory.Packages.props` and project files with `ManagedCode.Storage.Browser`, `ManagedCode.Storage.CloudKit`, `ManagedCode.Storage.Dropbox`, `ManagedCode.Storage.Google`, `ManagedCode.Storage.GoogleDrive`, `ManagedCode.Storage.OneDrive`, and `ManagedCode.Storage.VirtualFileSystem`.
+  - Extend `PrompterLiveServiceCollectionExtensions` with browser storage and VFS registration that matches the WASM runtime and keeps local browser storage as the default local provider.
+  - Verification before moving on:
+    - Build succeeds.
+    - New services resolve in the bUnit harness without startup failures.
+
+- [x] Step 3. Rework the local persistence boundary so storage integration does not regress runtime editing flows.
+  - Introduce a focused storage service layer that owns provider wiring, local browser containers, and snapshot transfer logic for scripts, folders, and settings.
+  - Keep `BrowserScriptRepository` and `BrowserLibraryFolderRepository` on an authoritative browser JSON/localStorage path with explicit materialization/versioning once the VFS-backed primary path proved unstable under real editor autosave flows.
+  - Keep `localStorage` limited to provider credentials/metadata, lightweight settings, and the authoritative runtime repository payloads that must remain stable in the browser-only app shape.
+  - Verification before moving on:
+    - Add or update tests for local script/folder/settings persistence and legacy bootstrap behavior.
+    - Confirm Library and Settings still load their existing defaults in tests.
+
+- [x] Step 4. Add provider connection models and secure-enough browser persistence for runtime credentials.
+  - Add provider configuration models, browser persistence services, and validation for Browser, CloudKit, Dropbox, Google Cloud Storage, Google Drive, and OneDrive.
+  - Persist only provider credentials/metadata in browser `localStorage` behind named storage keys and services.
+  - Verification before moving on:
+    - Add/update component tests that prove connection models save/load correctly and invalid configurations are rejected safely.
+    - Verify no raw credential literals are duplicated in implementation code.
+
+- [x] Step 5. Build cloud storage runtime services for scripts/settings import-export.
+  - Create a cloud storage orchestration service that can instantiate the requested provider at runtime from stored options and copy scripts/settings between local browser storage and the selected cloud provider.
+  - Use `IVirtualFileSystem` for local file layout and for cloud-facing file/directory operations where it simplifies implementation.
+  - Keep the feature limited to scripts and settings for now.
+  - Verification before moving on:
+    - Add automated tests for provider selection, import/export success, missing-credentials failures, and path layout.
+    - Validate at least the browser-local provider round-trip without mocks.
+
+- [x] Step 6. Replace the stub Settings Cloud UI with real provider configuration and actions.
+  - Rewrite `SettingsCloudSection.razor` and the owning `SettingsPage` partials so the Cloud section exposes provider cards, credential fields, connect/disconnect state, sync preferences, and import/export actions for scripts/settings.
+  - Add stable `UiTestIds` for the new controls and results.
+  - Keep the layout aligned with the Settings design language instead of shipping a purely utilitarian panel.
+  - Verification before moving on:
+    - Add/update bUnit assertions for Cloud section state, provider toggles, credential fields, and actions.
+    - Confirm the new UI contracts are all test-id addressable.
+
+- [x] Step 7. Document the architecture decision in an ADR and update architecture docs if boundaries changed.
+  - Write `docs/ADR/ADR-0001-browser-local-and-cloud-storage-vfs.md` documenting the browser-local default storage, localStorage credential policy, provider integration path, and deferred video-stream use case.
+  - Update `docs/Architecture.md` if the new storage service layer changes where contributors should place persistence and cloud-sync code.
+  - Verification before moving on:
+    - ADR has at least one Mermaid diagram and explicit verification methodology.
+    - Architecture doc reflects the new persistence boundary if ownership changed.
+
+- [x] Step 8. Add browser acceptance coverage and ship.
+  - Add or update a real Playwright Settings scenario that exercises the Cloud section, persists provider values, and proves scripts/settings import-export through the browser-backed provider.
+  - Capture screenshots under `output/playwright/`.
+  - Run the final validation in order:
+    - `dotnet build /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx -warnaserror`
+    - `dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.Core.Tests/PrompterLive.Core.Tests.csproj`
+    - `dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.App.Tests/PrompterLive.App.Tests.csproj`
+    - `dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.App.UITests/PrompterLive.App.UITests.csproj --no-build`
+    - `dotnet test /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx`
+    - `dotnet test /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx --collect:"XPlat Code Coverage"`
+    - `dotnet format /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx`
+  - Verification before moving on:
+    - All checklist items are complete.
+    - Working tree contains only intentional changes.
+  - Completed validation:
+    - `dotnet build /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx -warnaserror`
+    - `dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.Core.Tests/PrompterLive.Core.Tests.csproj`
+    - `dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.App.Tests/PrompterLive.App.Tests.csproj`
+    - `dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.App.UITests/PrompterLive.App.UITests.csproj --no-build`
+    - `dotnet test /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx`
+    - `dotnet test /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx --collect:"XPlat Code Coverage"`
+    - `dotnet format /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx`
+
+## Baseline Failures
+
+- [x] No pre-existing baseline failures in the relevant build, core, component, or browser suites.
+  - Build: `dotnet build /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx -warnaserror` passed.
+  - Core tests: `dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.Core.Tests/PrompterLive.Core.Tests.csproj --no-build` passed with `34/34`.
+  - App tests: `dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.App.Tests/PrompterLive.App.Tests.csproj --no-build` passed with `95/95`.
+  - UI tests: `dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.App.UITests/PrompterLive.App.UITests.csproj --no-build` passed with `76/76`.
+  - Root-cause note: an initial baseline attempt produced file-lock errors because multiple `dotnet` commands were launched in parallel against the same output folders; rerunning sequentially confirmed the repo baseline is green.
+  - Fix status: no inherited product failures need to be cleared before implementation.
+
+## Intended Fix Tracking
+
+- [x] Browser storage package and VFS wired into the WASM runtime.
+- [x] Local script and settings persistence now uses the new storage boundary without regressing runtime editor/library flows.
+- [x] Provider credentials stored via dedicated browser localStorage services.
+- [x] Settings Cloud section exposes real provider configuration instead of stub cards.
+- [x] Scripts and settings import/export work through the configured providers.
+- [x] ADR documents the new persistence/cloud boundary and risks.
+
+## Review Notes
+
+- [x] UI-test harness now resolves package `_content/*` assets from `staticwebassets.development.json`, which cleared the storage-package bootstrap failure in `PrompterLive.App.UITests`.
+- [x] The selected primary cloud provider now auto-opens its settings card so reload and first-use flows expose the active provider state without manual accordion recovery.
+
+## Validation Failures To Clear
+
+- [x] `LibraryScreenFlowTests.LibraryScreen_CreatesFolderAndMovesScript`
+  - Symptom: `library-new-folder-overlay` remained visible after the cancel/create flow in the full browser suite.
+  - Root cause: folder creation and move flows were relying on full reload timing instead of immediate local view-state updates.
+  - Fix status: cleared by local folder/script state application and explicit view-state persistence.
+
+- [x] `EditorInteractionTests.EditorScreen_FloatingToolbarShowsAiAndPersistsSelectionFormatting`
+  - Symptom: applying `Slow` after selecting `transformative moment` used stale editor selection state and did not update the intended text span.
+  - Root cause: toolbar commands could run before the textarea selection state was refreshed from the DOM.
+  - Fix status: cleared by explicit selection refresh before non-toggle toolbar actions.
+
+- [x] `EditorInteractionTests.EditorScreen_FullToolbarSurfaceSupportsExtendedCommands`
+  - Symptom: applying `Professional` after reselecting `transformative moment` wrapped the earlier `welcome` selection instead of the current target.
+  - Root cause: the same stale selection race as the floating-toolbar failure.
+  - Fix status: cleared by the same source-panel selection refresh path.
+
+- [x] `EditorTypingTests` and `EditorSourceSyncTests` full browser regressions
+  - Symptom: structure tree and first untitled-draft route assignment were unstable after the storage integration work.
+  - Root cause: the VFS-backed primary repository path caused first-save hangs in the real WASM autosave flow, and the untitled autosave path needed an explicit minimum-content guard for stability under parallel browser load.
+  - Fix status: cleared by restoring an authoritative browser JSON/localStorage repository path for runtime scripts/folders and by deferring untitled autosave until the draft has at least two non-whitespace characters.
+
+## Final Validation Skills
+
+- `dotnet-blazor`
+  - Reason: keep the storage and Settings integration aligned with the Blazor WASM runtime and component boundaries.
+  - Expected outcome: routed UI and service wiring stay component-owned and browser-safe.
+
+- `mcaf-adr-writing`
+  - Reason: record the browser-local plus cloud-provider storage decision, risks, and future video-upload direction.
+  - Expected outcome: an ADR with explicit trade-offs, implementation impact, and verification strategy.
+
+- `playwright`
+  - Reason: prove the Settings Cloud flow and browser-local storage behavior in a real browser.
+  - Expected outcome: passing acceptance flow with screenshot artifacts.

--- a/docs/ADR/ADR-0001-browser-vfs-and-cloud-storage.md
+++ b/docs/ADR/ADR-0001-browser-vfs-and-cloud-storage.md
@@ -1,0 +1,248 @@
+# ADR-0001: Browser VFS And Cloud Storage For Scripts And Settings
+
+Status: Implemented  
+Date: 2026-04-01  
+Related Features: [Architecture Overview](/Users/ksemenenko/Developer/PrompterLive/docs/Architecture.md)
+
+## Implementation plan (step-by-step)
+
+- [x] Analyze the existing browser-only storage shape for scripts, folders, and settings.
+- [x] Add ManagedCode.Storage packages and register browser storage plus virtual file system in the WASM host.
+- [x] Integrate browser storage plus VFS for cloud/import-export flows while keeping the primary script and folder runtime store on authoritative browser JSON/localStorage for product stability.
+- [x] Add provider preference and credential persistence for Dropbox, OneDrive, Google Drive, Google Cloud Storage, and CloudKit.
+- [x] Add scripts/settings import-export through the configured provider set.
+- [x] Add automated component and browser coverage for the new settings flow and storage contracts.
+- [x] Update architecture documentation and record this ADR.
+
+## Context
+
+- `PrompterLive` is a standalone Blazor WebAssembly app with no backend runtime.
+- Scripts and folders were persisted through ad-hoc browser localStorage JSON blobs.
+- The product now needs browser-local persistence plus optional cloud import/export for scripts and settings.
+- The user explicitly wants Managed Code storage providers, browser localStorage for provider keys and metadata, and no server-side secret store.
+- Future video-stream export is expected, but this task must stop at scripts and settings.
+
+Goals:
+
+- Keep the app browser-only.
+- Add a durable browser-storage boundary for cloud transfers now, while keeping the primary script and folder runtime path stable.
+- Let Settings configure real cloud providers for import/export.
+- Keep provider credentials and connection metadata in browser `localStorage`.
+
+Non-goals:
+
+- Recorded video upload or archive flows.
+- Background sync engines or multi-device conflict resolution.
+- OAuth popup/redirect orchestration hosted by PrompterLive.
+
+## Stakeholders
+
+| Role | What they need to know | Questions this ADR must answer |
+| --- | --- | --- |
+| Product | What users can store now and what is deferred | Can users keep scripts local-first and move them to cloud now? |
+| Engineering | Which boundary owns persistence and cloud transfers | Where do browser VFS, provider credentials, and import/export logic live? |
+| QA | Which flows must stay green | How do we verify local persistence, provider setup, and import/export safely? |
+| Security | Where secrets sit in a backend-free app | Why are provider credentials in browser localStorage, and what risk does that create? |
+
+## Decision
+
+PrompterLive will register `ManagedCode.Storage.Browser` plus `ManagedCode.Storage.VirtualFileSystem` inside the WASM host for browser-local blob storage and provider-backed transfers, while the primary day-to-day script and folder runtime store remains an authoritative browser JSON/localStorage repository. Browser `localStorage` also remains the store for provider credentials, provider metadata, and lightweight settings values. Cloud providers are configured in Settings and currently support snapshot import/export of scripts and settings only.
+
+Key points:
+
+- Primary scripts and folders stay on an authoritative browser JSON/localStorage path so editor/library autosave stays stable under real WASM browser flows.
+- Browser storage plus VFS remain active as the local storage abstraction for cloud snapshot import/export and future stream-export expansion.
+- Provider credentials stay client-side because the runtime has no backend secret store.
+- Cloud import/export is explicit and user-driven, not automatic bidirectional sync.
+- The requested Google Cloud Storage provider is implemented through the actual package `ManagedCode.Storage.Gcp`.
+
+## Diagram
+
+```mermaid
+flowchart LR
+    Settings["Settings UI"]
+    BrowserStore["BrowserCloudStorageStore"]
+    LocalStorage["browser localStorage<br/>credentials + provider metadata"]
+    Transfer["CloudStorageTransferService"]
+    ProviderFactory["CloudStorageProviderFactory"]
+    LocalRuntime["Browser JSON/localStorage<br/>authoritative scripts + folders"]
+    LocalVfs["IVirtualFileSystem"]
+    BrowserProvider["ManagedCode.Storage.Browser<br/>IndexedDB + OPFS"]
+    Scripts["BrowserScriptRepository"]
+    Folders["BrowserLibraryFolderRepository"]
+    Providers["Dropbox / OneDrive / Google Drive / GCS / CloudKit"]
+
+    Settings --> BrowserStore
+    BrowserStore --> LocalStorage
+    Settings --> Transfer
+    Transfer --> ProviderFactory
+    Transfer --> LocalVfs
+    Scripts --> LocalRuntime
+    Folders --> LocalRuntime
+    LocalVfs --> BrowserProvider
+    ProviderFactory --> Providers
+```
+
+## Alternatives considered
+
+### Keep everything in ad-hoc localStorage blobs
+
+- Pros: minimal code churn, no extra package integration.
+- Cons: no file model, no VFS abstraction, brittle migration path, harder future expansion to cloud or stream artifacts.
+- Rejected because the product now needs a durable storage boundary and provider-backed transfers.
+
+### Introduce a backend for secrets and sync
+
+- Pros: stronger secret handling, server-owned OAuth flows, easier centralized sync.
+- Cons: violates the browser-only runtime, adds deployment and operational scope, blocks the current delivery target.
+- Rejected because the app must remain standalone WASM.
+
+### Add live cloud sync instead of snapshot import/export
+
+- Pros: tighter cloud parity across devices.
+- Cons: conflict resolution, offline semantics, provider-specific edge cases, higher failure surface.
+- Rejected because scripts/settings transfer is needed now, while continuous sync is not.
+
+## Consequences
+
+### Positive
+
+- Cloud transfer and future media-export work now have a real browser-storage and VFS abstraction available inside the app boundary.
+- Cloud providers can be connected without introducing backend infrastructure.
+- Import/export logic is isolated from page markup and provider SDK details.
+- The storage boundary is reusable for later video-stream export work without forcing the editor and library to ride a less stable primary persistence path today.
+
+### Negative / risks
+
+- Provider credentials live in browser localStorage and are therefore exposed to the current browser profile.
+  Mitigation: keep the app backend-free by design, persist only the provider credentials and metadata required for runtime use, and document that these connections are browser-profile scoped.
+- Cloud import/export is a snapshot flow, so concurrent edits across devices can overwrite expectations.
+  Mitigation: keep transfers explicit and user-triggered, not silent background sync.
+- Browser test infrastructure must serve static web assets for storage packages as well as app assets.
+  Mitigation: the UI test harness now reads `staticwebassets.development.json` and maps package `_content/*` assets dynamically.
+
+## Impact
+
+### Code
+
+- Affected modules and services:
+  - `src/PrompterLive.Shared/AppShell/Services/PrompterLiveServiceCollectionExtensions.cs`
+  - `src/PrompterLive.Shared/Library/Services/Storage/*`
+  - `src/PrompterLive.Shared/Storage/*`
+  - `src/PrompterLive.Shared/Storage/Cloud/*`
+  - `src/PrompterLive.Shared/Settings/Components/SettingsCloudSection.*`
+  - `tests/PrompterLive.App.Tests/Settings/*`
+  - `tests/PrompterLive.App.UITests/Settings/*`
+  - `tests/PrompterLive.App.UITests/Infrastructure/*`
+- New boundaries and responsibilities:
+  - Browser JSON/localStorage owns primary script and folder runtime persistence.
+  - Browser storage plus VFS own the local blob boundary used by cloud import/export and future expansion.
+  - `BrowserCloudStorageStore` owns provider preference and credential persistence.
+  - `CloudStorageTransferService` owns snapshot import/export.
+  - `CloudStorageProviderFactory` owns runtime provider construction and validation.
+- Feature flags and toggles:
+  - none
+
+### Data / configuration
+
+- Scripts and folders now materialize into authoritative browser JSON/localStorage payloads with an explicit version marker so seed data and user changes stay stable across reloads.
+- Browser storage plus VFS stay registered for provider-backed transfers instead of becoming the primary editor/library persistence path.
+- Browser localStorage keys remain the source of truth for provider credentials and metadata.
+- No server secrets, environment variables, or backend config were added.
+
+### Documentation
+
+- Architecture docs updated in [docs/Architecture.md](/Users/ksemenenko/Developer/PrompterLive/docs/Architecture.md).
+- This ADR is the source of truth for the storage boundary and credential policy.
+- Root `AGENTS.md` now records the durable rule that standalone cloud credentials live in browser localStorage.
+
+## Verification
+
+### Objectives
+
+- Prove that local scripts and folders persist through the authoritative browser JSON/localStorage path without editor autosave hangs.
+- Prove that cloud provider preferences and credentials persist through browser localStorage.
+- Prove that the Settings cloud flow works in a real browser, including reload behavior.
+- Prove that the UI-test self-hosted server can boot the app with package static assets present.
+
+### Test environment
+
+- Environment: local browser-hosted WASM runtime and self-hosted Playwright acceptance harness.
+- Data and reset strategy: browser-local seed data only; tests rely on isolated runtime contexts.
+- External dependencies: no real cloud credentials required for the regression suite; validation paths cover safe failure messages and state persistence.
+
+### Testing methodology
+
+- Core flows and invariants that must be proven:
+  - scripts and folders persist locally through the authoritative browser repository path
+  - provider settings survive reload
+  - the chosen primary cloud provider opens and remains configurable after reload
+  - invalid provider credentials fail safely with a visible validation message
+- Positive flows that must pass:
+  - component-level persistence for cloud preferences
+  - browser-level configuration and reload of the Dropbox provider path
+- Negative and safe-failure flows that must be covered:
+  - missing Dropbox credentials do not connect and instead surface validation text
+  - disconnect removes stored credentials and resets the UI subtitle
+- Edge flows that must be covered:
+  - runtime seed data and existing browser-local payloads can still materialize into the authoritative repositories without resurrecting deleted items
+  - self-hosted browser suite serves package `_content/*` assets from the static web assets manifest
+- Required realism level:
+  - real browser flow for acceptance
+  - no mocks or service doubles in verification flows added for this change
+- Pass criteria:
+  - build, relevant tests, full solution tests, coverage, and format all pass
+
+### Test commands
+
+- build: `dotnet build /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx -warnaserror`
+- test: `dotnet test /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx`
+- format: `dotnet format /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx`
+- coverage: `dotnet test /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx --collect:"XPlat Code Coverage"`
+
+### New or changed tests
+
+| ID | Scenario | Level | Expected result | Notes |
+| --- | --- | --- | --- | --- |
+| TST-001 | Save Dropbox draft settings and reload the Settings page | UI | Provider selection, label, and validation message persist | `SettingsCloudStorageFlowTests` |
+| TST-002 | Disconnect Dropbox and clear persisted credentials | Component | Credentials are removed and subtitle resets to disconnected | `SettingsInteractionTests` |
+| TST-003 | Load the stored primary provider and auto-open its card | Component | Selected provider card renders open after state load | `SettingsInteractionTests` |
+
+### Regression and analysis
+
+- Regression suites to run:
+  - `tests/PrompterLive.Core.Tests`
+  - `tests/PrompterLive.App.Tests`
+  - `tests/PrompterLive.App.UITests`
+  - full solution tests
+- Static analysis:
+  - repo build under `-warnaserror`
+  - `dotnet format`
+- Coverage comparison:
+  - solution coverage must stay at least at the previous baseline or improve
+
+## Rollout and migration
+
+- Migration steps:
+  - ship the browser-storage and VFS wiring with the updated Settings UI
+  - allow repository services to materialize runtime seeds and prior browser payloads into authoritative local browser JSON on first mutation
+- Backwards compatibility:
+  - existing local library payloads are read and migrated instead of being dropped
+  - settings still use browser-local persistence
+- Rollback:
+  - revert the storage wiring, cloud UI, and repository changes together; partial rollback would break the storage boundary
+
+## References
+
+- [managedcode/Storage](https://github.com/managedcode/Storage)
+- [ManagedCode Storage docs](https://storage.managed-code.com/)
+- [docs/Architecture.md](/Users/ksemenenko/Developer/PrompterLive/docs/Architecture.md)
+
+## Filing checklist
+
+- [x] File saved under `docs/ADR/ADR-0001-browser-vfs-and-cloud-storage.md`.
+- [x] Status reflects the implemented state.
+- [x] Diagram section contains at least one Mermaid diagram.
+- [x] Testing methodology includes positive, negative, and edge flows plus pass criteria.
+- [x] New or updated automated tests exist for the changed behaviour.
+- [x] `docs/Architecture.md` updated for the new storage boundary.

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -97,6 +97,7 @@ flowchart LR
 | `Teleprompter` | Read-mode playback surface | Presents the script for live reading with camera-backed composition | `src/PrompterLive.Shared/Teleprompter` | reading layout, background camera composition, runtime reading flow | script persistence rules, destination setup screens |
 | `GoLive` | Live production and routing surface | Arms outputs, switches sources, previews cameras, and exposes live telemetry | `src/PrompterLive.Shared/GoLive`, `src/PrompterLive.Core/Streaming` | studio layout, output controls, destination routing, live session state | server-side stream processing, unrelated editor or library concerns |
 | `Settings` | Device and scene setup surface | Configures cameras, microphones, overlays, and base scene state | `src/PrompterLive.Shared/Settings`, `src/PrompterLive.Core/Media` | device selection UI, scene transforms, scene persistence flows | live output orchestration policy, document editing |
+| `Storage` | Browser persistence and cloud transfer orchestration | Keeps scripts and settings local-first while exposing provider-backed import/export | `src/PrompterLive.Shared/Storage`, `src/PrompterLive.Shared/Library/Services/Storage` | browser `IStorage` and VFS registration, authoritative browser repositories for scripts/folders, provider credential persistence, scripts/settings snapshot transfer | routed page layout, teleprompter rendering, video-stream upload workflows |
 | `Diagnostics` | Error and operation feedback layer | Makes recoverable and fatal issues visible in the shell | `src/PrompterLive.Shared/Diagnostics` | banners, error boundary reporting, operation status wiring | owning business logic of the failing feature |
 | `Localization` | Culture and UI text contract | Keeps supported runtime languages consistent and browser-driven | `src/PrompterLive.Shared/Localization`, `src/PrompterLive.Core/Localization` | text catalogs, culture bootstrap, supported culture rules | feature behavior or screen-specific layout ownership |
 | `Workspace` | Active script/session state model | Gives editor, learn, read, and go-live one shared script context | `src/PrompterLive.Core/Workspace` | loaded script state, previews, estimated duration, active session metadata | feature-specific rendering details |
@@ -122,8 +123,9 @@ flowchart TD
     Ui["PrompterLive.Shared"]
     Domain["PrompterLive.Core"]
     Localization["Culture bootstrap + localized UI catalog"]
-    BrowserStorage["Browser storage adapters<br/>documents + folders + settings"]
-    WebApis["localStorage / MediaDevices / Canvas / JS helpers"]
+    BrowserStorage["Browser storage + repository adapters<br/>scripts + folders + settings"]
+    CloudStorage["Cloud provider orchestration<br/>snapshot import/export"]
+    WebApis["localStorage / IndexedDB / OPFS / MediaDevices / Canvas / JS helpers"]
 
     Browser --> WasmHost
     WasmHost --> Ui
@@ -131,7 +133,9 @@ flowchart TD
     WasmHost --> Localization
     Ui --> Localization
     Ui --> BrowserStorage
+    Ui --> CloudStorage
     BrowserStorage --> WebApis
+    CloudStorage --> WebApis
     Ui --> WebApis
 ```
 
@@ -145,16 +149,55 @@ flowchart LR
     FolderRepo["ILibraryFolderRepository"]
     CardFactory["LibraryCardFactory"]
     TreeBuilder["LibraryFolderTreeBuilder"]
-    LocalStorage["localStorage adapters"]
+    BrowserRepo["Authoritative browser repositories<br/>localStorage JSON + materialization"]
+    BrowserStorage["ManagedCode.Storage.Browser<br/>IndexedDB + OPFS"]
+    LegacySeed["Seed materialization + legacy cleanup"]
 
     LibraryPage --> FolderChips
     LibraryPage --> ScriptRepo
     LibraryPage --> FolderRepo
     LibraryPage --> CardFactory
     LibraryPage --> TreeBuilder
-    ScriptRepo --> LocalStorage
-    FolderRepo --> LocalStorage
+    ScriptRepo --> BrowserRepo
+    FolderRepo --> BrowserRepo
+    BrowserRepo --> BrowserStorage
+    ScriptRepo --> LegacySeed
+    FolderRepo --> LegacySeed
 ```
+
+## Storage And Cloud Contracts
+
+```mermaid
+flowchart LR
+    Settings["SettingsCloudSection"]
+    BrowserStore["BrowserCloudStorageStore"]
+    Preferences["CloudStoragePreferences"]
+    BrowserKeys["BrowserSettingsStore<br/>localStorage keys only"]
+    Transfer["CloudStorageTransferService"]
+    ProviderFactory["CloudStorageProviderFactory"]
+    LocalRepo["BrowserScriptRepository + BrowserLibraryFolderRepository"]
+    LocalVfs["IVirtualFileSystem"]
+    ScriptRepo["BrowserScriptRepository"]
+    FolderRepo["BrowserLibraryFolderRepository"]
+    BrowserProvider["ManagedCode.Storage.Browser"]
+    Providers["Dropbox / OneDrive / Google Drive / GCS / CloudKit"]
+
+    Settings --> BrowserStore
+    Settings --> Transfer
+    BrowserStore --> Preferences
+    BrowserStore --> BrowserKeys
+    Transfer --> ProviderFactory
+    Transfer --> LocalVfs
+    ScriptRepo --> LocalRepo
+    FolderRepo --> LocalRepo
+    LocalVfs --> BrowserProvider
+    ProviderFactory --> Providers
+```
+
+- Scripts and folders persist through authoritative browser repositories backed by versioned JSON/localStorage materialization.
+- Browser `localStorage` is reserved for provider credentials, provider metadata, and lightweight settings values that must survive reloads.
+- Browser storage plus VFS stay registered for cloud import/export and future stream-export work, but they are not the primary editor/library persistence path today.
+- Cloud import/export currently moves one scripts-and-settings snapshot at a time; it is not a live sync engine and does not own recorded video upload.
 
 ## Editor Authoring Contracts
 
@@ -391,7 +434,7 @@ sequenceDiagram
 
     Shared->>Core: Parse / compile TPS
     Shared->>Core: Calculate RSVP and reader state
-    Shared->>Browser: Persist settings and local documents
+    Shared->>Browser: Persist settings, authoritative browser documents, and cloud credentials
     Shared->>Browser: Drive design interactions from app.js
 ```
 

--- a/src/PrompterLive.Core/Workspace/Services/ScriptSessionService.cs
+++ b/src/PrompterLive.Core/Workspace/Services/ScriptSessionService.cs
@@ -27,8 +27,7 @@ public sealed class ScriptSessionService(
 
     public async Task InitializeAsync(CancellationToken cancellationToken = default)
     {
-        _logger.LogInformation("Initializing script session repository and empty draft.");
-        await _repository.InitializeAsync([], cancellationToken);
+        _logger.LogInformation("Initializing script session draft state.");
         await NewAsync(cancellationToken);
     }
 

--- a/src/PrompterLive.Shared/AppShell/Services/AppBootstrapper.cs
+++ b/src/PrompterLive.Shared/AppShell/Services/AppBootstrapper.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using PrompterLive.Core.Abstractions;
 using PrompterLive.Core.Models.Media;
 using PrompterLive.Core.Models.Workspace;
+using PrompterLive.Shared.Storage;
 
 namespace PrompterLive.Shared.Services;
 
@@ -14,10 +15,6 @@ public sealed class AppBootstrapper(
     BrowserSettingsStore settingsStore,
     ILogger<AppBootstrapper>? logger = null)
 {
-    private const string ReaderSettingsKey = "prompterlive.reader";
-    private const string LearnSettingsKey = "prompterlive.learn";
-    private const string SceneSettingsKey = "prompterlive.scene";
-
     private readonly IScriptSessionService _sessionService = sessionService;
     private readonly IScriptRepository _scriptRepository = scriptRepository;
     private readonly ILibraryFolderRepository _libraryFolderRepository = libraryFolderRepository;
@@ -50,21 +47,21 @@ public sealed class AppBootstrapper(
             await _scriptRepository.InitializeAsync(RuntimeLibrarySeedCatalog.CreateDocuments(), cancellationToken);
             await _sessionService.InitializeAsync(cancellationToken);
 
-            var readerSettings = await _settingsStore.LoadAsync<ReaderSettings>(ReaderSettingsKey, cancellationToken);
+            var readerSettings = await _settingsStore.LoadAsync<ReaderSettings>(BrowserAppSettingsKeys.ReaderSettings, cancellationToken);
             if (readerSettings is not null)
             {
                 _logger.LogInformation("Restoring reader settings from browser storage.");
                 await _sessionService.UpdateReaderSettingsAsync(readerSettings);
             }
 
-            var learnSettings = await _settingsStore.LoadAsync<LearnSettings>(LearnSettingsKey, cancellationToken);
+            var learnSettings = await _settingsStore.LoadAsync<LearnSettings>(BrowserAppSettingsKeys.LearnSettings, cancellationToken);
             if (learnSettings is not null)
             {
                 _logger.LogInformation("Restoring learn settings from browser storage.");
                 await _sessionService.UpdateLearnSettingsAsync(learnSettings);
             }
 
-            var mediaScene = await _settingsStore.LoadAsync<MediaSceneState>(SceneSettingsKey, cancellationToken);
+            var mediaScene = await _settingsStore.LoadAsync<MediaSceneState>(BrowserAppSettingsKeys.SceneSettings, cancellationToken);
             if (mediaScene is not null)
             {
                 _logger.LogInformation("Restoring media scene from browser storage.");

--- a/src/PrompterLive.Shared/AppShell/Services/PrompterLiveServiceCollectionExtensions.cs
+++ b/src/PrompterLive.Shared/AppShell/Services/PrompterLiveServiceCollectionExtensions.cs
@@ -1,3 +1,6 @@
+using ManagedCode.Storage.Browser.Extensions;
+using ManagedCode.Storage.Core.Extensions;
+using ManagedCode.Storage.VirtualFileSystem.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using PrompterLive.Core.Abstractions;
 using PrompterLive.Core.Services;
@@ -9,6 +12,8 @@ using PrompterLive.Core.Services.Streaming;
 using PrompterLive.Core.Services.Workspace;
 using PrompterLive.Shared.Services.Diagnostics;
 using PrompterLive.Shared.Services.Editor;
+using PrompterLive.Shared.Storage;
+using PrompterLive.Shared.Storage.Cloud;
 
 namespace PrompterLive.Shared.Services;
 
@@ -16,6 +21,19 @@ public static class PrompterLiveServiceCollectionExtensions
 {
     public static IServiceCollection AddPrompterLiveShared(this IServiceCollection services)
     {
+        services.AddStorageFactory();
+        services.AddBrowserStorageAsDefault(options =>
+        {
+            options.ContainerName = PrompterStorageDefaults.LocalBrowserContainerName;
+            options.DatabaseName = PrompterStorageDefaults.LocalBrowserDatabaseName;
+            options.ChunkSizeBytes = PrompterStorageDefaults.BrowserChunkSizeBytes;
+            options.ChunkBatchSize = PrompterStorageDefaults.BrowserChunkBatchSize;
+        });
+        services.AddVirtualFileSystem(options =>
+        {
+            options.DefaultContainer = PrompterStorageDefaults.LocalBrowserContainerName;
+        });
+
         services.AddScoped<TpsParser>();
         services.AddScoped<ScriptCompiler>();
         services.AddScoped<TpsExporter>();
@@ -38,7 +56,10 @@ public static class PrompterLiveServiceCollectionExtensions
         services.AddScoped<IMediaDeviceService, BrowserMediaDeviceService>();
         services.AddScoped<IMediaSceneService, MediaSceneService>();
         services.AddScoped<BrowserSettingsStore>();
+        services.AddScoped<BrowserCloudStorageStore>();
         services.AddScoped<BrowserThemeService>();
+        services.AddScoped<CloudStorageProviderFactory>();
+        services.AddScoped<CloudStorageTransferService>();
         services.AddScoped<StudioSettingsStore>();
         services.AddScoped<CameraPreviewInterop>();
         services.AddScoped<LearnRsvpLayoutInterop>();

--- a/src/PrompterLive.Shared/Contracts/UiTestIds.cs
+++ b/src/PrompterLive.Shared/Contracts/UiTestIds.cs
@@ -223,8 +223,11 @@ public static class UiTestIds
         public const string CameraRoutingCta = Header.GoLive;
         public const string CameraMirrorToggle = "settings-camera-mirror-toggle";
         public const string CameraResolution = "settings-camera-resolution";
+        public const string CloudAutoSyncOnSave = "settings-cloud-auto-sync-on-save";
+        public const string CloudDefaultProvider = "settings-cloud-default-provider";
         public const string CamerasPanel = "settings-cameras-panel";
         public const string CloudPanel = "settings-cloud-panel";
+        public const string CloudSyncOnStartup = "settings-cloud-sync-on-startup";
         public const string DefaultCamera = "settings-default-camera";
         public const string EchoCancellation = "settings-echo-cancellation";
         public const string FileAutoSave = "settings-file-autosave";
@@ -295,6 +298,22 @@ public static class UiTestIds
         public static string CameraDeviceAction(string deviceId) => $"settings-camera-device-action-{deviceId}";
 
         public static string CameraPrimaryAction(string deviceId) => $"settings-camera-primary-{deviceId}";
+
+        public static string CloudProviderCard(string providerId) => $"settings-cloud-{providerId}-card";
+
+        public static string CloudProviderConnect(string providerId) => $"settings-cloud-{providerId}-connect";
+
+        public static string CloudProviderDisconnect(string providerId) => $"settings-cloud-{providerId}-disconnect";
+
+        public static string CloudProviderExport(string providerId) => $"settings-cloud-{providerId}-export";
+
+        public static string CloudProviderField(string providerId, string fieldId) => $"settings-cloud-{providerId}-{fieldId}";
+
+        public static string CloudProviderImport(string providerId) => $"settings-cloud-{providerId}-import";
+
+        public static string CloudProviderMessage(string providerId) => $"settings-cloud-{providerId}-message";
+
+        public static string CloudProviderSubtitle(string providerId) => $"settings-cloud-{providerId}-subtitle";
 
         public static string MicDelay(string deviceId) => $"settings-mic-delay-{deviceId}";
 

--- a/src/PrompterLive.Shared/Editor/Components/EditorSourcePanel.ToolbarState.cs
+++ b/src/PrompterLive.Shared/Editor/Components/EditorSourcePanel.ToolbarState.cs
@@ -24,6 +24,11 @@ public partial class EditorSourcePanel
 
     private async Task ExecuteToolbarActionAsync(EditorToolbarActionDescriptor action)
     {
+        if (action.ActionType != EditorToolbarActionType.ToggleMenu)
+        {
+            await RefreshSelectionAsync(requestComponentRender: false);
+        }
+
         switch (action.ActionType)
         {
             case EditorToolbarActionType.ToggleMenu:

--- a/src/PrompterLive.Shared/Editor/Pages/EditorPage.DocumentComposition.cs
+++ b/src/PrompterLive.Shared/Editor/Pages/EditorPage.DocumentComposition.cs
@@ -11,7 +11,7 @@ public partial class EditorPage
         var mutation = LocalAssistant.Apply(_sourceText, _selection.Range, action);
         _selection = _selection with { Range = mutation.Selection };
         _history.TryRecord(mutation.Text, mutation.Selection);
-        await PersistDraftAsync(mutation.Text);
+        PersistDraftInBackground(mutation.Text);
 
         if (_sourcePanel is not null)
         {

--- a/src/PrompterLive.Shared/Editor/Pages/EditorPage.Loading.cs
+++ b/src/PrompterLive.Shared/Editor/Pages/EditorPage.Loading.cs
@@ -7,6 +7,7 @@ public partial class EditorPage
 {
     protected override Task OnParametersSetAsync()
     {
+        _isEditorReady = false;
         _loadState = true;
         return Task.CompletedTask;
     }
@@ -29,6 +30,9 @@ public partial class EditorPage
                 PopulateEditorState(resetHistory: true);
                 StateHasChanged();
             });
+
+        _isEditorReady = true;
+        StateHasChanged();
     }
 
     private async Task EnsureSessionLoadedAsync()
@@ -60,6 +64,11 @@ public partial class EditorPage
         var document = _frontMatterService.Parse(state.Text);
         var metadata = document.Metadata;
         var computedDuration = FormatDuration(state.EstimatedDuration);
+
+        if (resetHistory)
+        {
+            _draftRevision = checked(_draftRevision + 1);
+        }
 
         _sourceText = document.Body;
         _screenTitle = _frontMatterService.ResolveTitle(state.Text, state.Title);

--- a/src/PrompterLive.Shared/Editor/Pages/EditorPage.Persistence.cs
+++ b/src/PrompterLive.Shared/Editor/Pages/EditorPage.Persistence.cs
@@ -1,3 +1,5 @@
+using PrompterLive.Core.Services.Workspace;
+
 namespace PrompterLive.Shared.Pages;
 
 public partial class EditorPage
@@ -6,14 +8,38 @@ public partial class EditorPage
     {
         CancelDraftAnalysis();
         CancelAutosave();
-        await UpdateDraftStateAsync(text, persistDocument: true, CancellationToken.None);
+        var revision = PrepareDraftPersistence(text);
+        await PersistPreparedDraftAsync(text, revision, CancellationToken.None);
     }
 
-    private async Task UpdateDraftStateAsync(string text, bool persistDocument, CancellationToken cancellationToken)
+    private long PrepareDraftPersistence(string text)
     {
         _sourceText = text ?? string.Empty;
+        RefreshDraftViewFromSource();
+        _ = InvokeAsync(StateHasChanged);
+        return checked(++_draftRevision);
+    }
+
+    private void PersistDraftInBackground(string text)
+    {
+        CancelDraftAnalysis();
+        CancelAutosave();
+        var revision = PrepareDraftPersistence(text);
+        _ = InvokeAsync(() => PersistPreparedDraftAsync(text, revision, CancellationToken.None));
+    }
+
+    private Task PersistPreparedDraftAsync(string text, long revision, CancellationToken cancellationToken) =>
+        UpdateDraftStateAsync(text, persistDocument: true, cancellationToken, revision);
+
+    private async Task UpdateDraftStateAsync(
+        string text,
+        bool persistDocument,
+        CancellationToken cancellationToken,
+        long revision)
+    {
         var persistedText = BuildPersistedDocument(_sourceText);
         var title = _screenTitle;
+        var assignScriptId = string.IsNullOrWhiteSpace(ScriptId);
         await Diagnostics.RunAsync(
             PersistDraftOperation,
             PersistDraftMessage,
@@ -29,21 +55,56 @@ public partial class EditorPage
                 if (persistDocument)
                 {
                     var savedDocument = await SessionService.SaveAsync(cancellationToken);
-                    if (string.IsNullOrWhiteSpace(ScriptId))
+                    if (assignScriptId)
                     {
+                        if (revision != _draftRevision)
+                        {
+                            StageDraftIdentity(savedDocument.Id, savedDocument.DocumentName);
+                        }
+
                         ScriptId = savedDocument.Id;
                         Navigation.NavigateTo($"/editor?id={Uri.EscapeDataString(savedDocument.Id)}", replace: true);
                     }
                 }
 
-                PopulateEditorState();
+                ApplyPersistedDraftState(revision);
             },
             clearRecoverableOnSuccess: string.IsNullOrWhiteSpace(SessionService.State.ErrorMessage));
+    }
+
+    private void StageDraftIdentity(string scriptId, string documentName)
+    {
+        if (SessionService is not ScriptSessionService sessionService)
+        {
+            return;
+        }
+
+        sessionService.StageDraftText(
+            _screenTitle,
+            BuildPersistedDocument(_sourceText),
+            documentName,
+            scriptId,
+            _errorMessage);
+    }
+
+    private void ApplyPersistedDraftState(long revision)
+    {
+        if (revision != _draftRevision)
+        {
+            return;
+        }
+
+        PopulateEditorState();
     }
 
     private void QueueAutosave()
     {
         CancelAutosave();
+        if (!ShouldQueueAutosave())
+        {
+            return;
+        }
+
         _autosaveCancellationSource = new CancellationTokenSource();
         _ = RunAutosaveAsync(_autosaveCancellationSource.Token);
     }
@@ -128,4 +189,14 @@ public partial class EditorPage
         string.IsNullOrWhiteSpace(SessionService.State.ScriptId)
             ? UntitledDraftAutosaveDelayMilliseconds
             : AutosaveDelayMilliseconds;
+
+    private bool ShouldQueueAutosave()
+    {
+        if (!string.IsNullOrWhiteSpace(SessionService.State.ScriptId))
+        {
+            return true;
+        }
+
+        return _sourceText.Trim().Length >= UntitledDraftAutosaveCharacterThreshold;
+    }
 }

--- a/src/PrompterLive.Shared/Editor/Pages/EditorPage.SourceEditing.cs
+++ b/src/PrompterLive.Shared/Editor/Pages/EditorPage.SourceEditing.cs
@@ -102,7 +102,7 @@ public partial class EditorPage
     {
         _selection = _selection with { Range = selection };
         _history.TryRecord(text, selection);
-        await PersistDraftAsync(text);
+        PersistDraftInBackground(text);
         await FocusSourceRangeAsync(selection.Start, selection.End);
     }
 

--- a/src/PrompterLive.Shared/Editor/Pages/EditorPage.razor
+++ b/src/PrompterLive.Shared/Editor/Pages/EditorPage.razor
@@ -5,45 +5,54 @@
 <div id="screen-editor"
      class="screen active"
      data-testid="@UiTestIds.Editor.Page">
-    <div class="ed-layout">
-        <EditorStructureSidebar Segments="@_segments"
-                                ActiveSegmentIndex="@_activeSegmentIndex"
-                                ActiveBlockIndex="@_activeBlockIndex"
-                                OnNavigate="OnNavigateAsync" />
+    @if (!_isEditorReady)
+    {
+        <div class="app-loading-shell" aria-busy="true">
+            <div class="app-loading-mark">PL</div>
+        </div>
+    }
+    else
+    {
+        <div class="ed-layout">
+            <EditorStructureSidebar Segments="@_segments"
+                                    ActiveSegmentIndex="@_activeSegmentIndex"
+                                    ActiveBlockIndex="@_activeBlockIndex"
+                                    OnNavigate="OnNavigateAsync" />
 
-        <EditorSourcePanel @ref="_sourcePanel"
-                           Text="@_sourceText"
-                           Selection="@_selection"
-                           Status="@_status"
-                           CanUndo="@_history.CanUndo"
-                           CanRedo="@_history.CanRedo"
-                           ErrorMessage="@_errorMessage"
-                           OnTextChanged="OnSourceChangedAsync"
-                           OnSelectionChanged="OnSelectionChangedAsync"
-                           OnHistoryRequested="OnHistoryRequestedAsync"
-                           OnCommandRequested="OnCommandRequestedAsync"
-                           OnAiActionRequested="OnAiActionRequestedAsync" />
+            <EditorSourcePanel @ref="_sourcePanel"
+                               Text="@_sourceText"
+                               Selection="@_selection"
+                               Status="@_status"
+                               CanUndo="@_history.CanUndo"
+                               CanRedo="@_history.CanRedo"
+                               ErrorMessage="@_errorMessage"
+                               OnTextChanged="OnSourceChangedAsync"
+                               OnSelectionChanged="OnSelectionChangedAsync"
+                               OnHistoryRequested="OnHistoryRequestedAsync"
+                               OnCommandRequested="OnCommandRequestedAsync"
+                               OnAiActionRequested="OnAiActionRequestedAsync" />
 
-        <EditorMetadataRail Profile="@_profile"
-                            BaseWpm="@_baseWpm"
-                            Duration="@_displayDuration"
-                            XslowOffset="@_xslowOffset"
-                            SlowOffset="@_slowOffset"
-                            FastOffset="@_fastOffset"
-                            XfastOffset="@_xfastOffset"
-                            Author="@_author"
-                            CreatedDate="@_createdDate"
-                            Version="@_version"
-                            Status="@_status"
-                            ProfileChanged="OnProfileChangedAsync"
-                            BaseWpmChanged="OnBaseWpmChangedAsync"
-                            DurationChanged="OnDurationChangedAsync"
-                            XslowOffsetChanged="OnXslowOffsetChangedAsync"
-                            SlowOffsetChanged="OnSlowOffsetChangedAsync"
-                            FastOffsetChanged="OnFastOffsetChangedAsync"
-                            XfastOffsetChanged="OnXfastOffsetChangedAsync"
-                            AuthorChanged="OnAuthorChangedAsync"
-                            CreatedDateChanged="OnCreatedDateChangedAsync"
-                            VersionChanged="OnVersionChangedAsync" />
-    </div>
+            <EditorMetadataRail Profile="@_profile"
+                                BaseWpm="@_baseWpm"
+                                Duration="@_displayDuration"
+                                XslowOffset="@_xslowOffset"
+                                SlowOffset="@_slowOffset"
+                                FastOffset="@_fastOffset"
+                                XfastOffset="@_xfastOffset"
+                                Author="@_author"
+                                CreatedDate="@_createdDate"
+                                Version="@_version"
+                                Status="@_status"
+                                ProfileChanged="OnProfileChangedAsync"
+                                BaseWpmChanged="OnBaseWpmChangedAsync"
+                                DurationChanged="OnDurationChangedAsync"
+                                XslowOffsetChanged="OnXslowOffsetChangedAsync"
+                                SlowOffsetChanged="OnSlowOffsetChangedAsync"
+                                FastOffsetChanged="OnFastOffsetChangedAsync"
+                                XfastOffsetChanged="OnXfastOffsetChangedAsync"
+                                AuthorChanged="OnAuthorChangedAsync"
+                                CreatedDateChanged="OnCreatedDateChangedAsync"
+                                VersionChanged="OnVersionChangedAsync" />
+        </div>
+    }
 </div>

--- a/src/PrompterLive.Shared/Editor/Pages/EditorPage.razor.cs
+++ b/src/PrompterLive.Shared/Editor/Pages/EditorPage.razor.cs
@@ -21,6 +21,7 @@ public partial class EditorPage
     private const int DraftAnalysisDelayMilliseconds = 1_000;
     private const int AutosaveDelayMilliseconds = 1_500;
     private const int UntitledDraftAutosaveDelayMilliseconds = 1_500;
+    private const int UntitledDraftAutosaveCharacterThreshold = 2;
     private const string DefaultAuthor = "PrompterLive";
     private const string DefaultProfileActor = "Actor";
     private const string DefaultProfileRsvp = "RSVP";
@@ -30,6 +31,8 @@ public partial class EditorPage
     private readonly TpsFrontMatterDocumentService _frontMatterService = new();
     private CancellationTokenSource? _draftAnalysisCancellationSource;
     private CancellationTokenSource? _autosaveCancellationSource;
+    private long _draftRevision;
+    private bool _isEditorReady;
     private bool _loadState = true;
     private int? _activeBlockIndex;
     private int _activeSegmentIndex;

--- a/src/PrompterLive.Shared/Library/Pages/LibraryPage.Folders.cs
+++ b/src/PrompterLive.Shared/Library/Pages/LibraryPage.Folders.cs
@@ -62,8 +62,8 @@ public partial class LibraryPage
                 var folder = await LibraryFolderRepository.CreateAsync(folderName, parentId);
                 ExpandCreatedFolderPath(folder.Id, parentId);
                 ResetFolderDraftState(folder.Id);
+                ApplyCreatedFolder(folder);
                 Logger.LogInformation(FolderCreatedLogTemplate, folder.Id, parentId ?? LibrarySelectionKeys.Root);
-                await LoadLibraryAsync();
                 await PersistViewStateAsync();
             });
     }
@@ -84,6 +84,18 @@ public partial class LibraryPage
         _folderDraftName = string.Empty;
         _folderDraftParentId = ResolveDraftParentId();
         _selectedFolderId = selectedFolderId;
+    }
+
+    private void ApplyCreatedFolder(StoredLibraryFolder folder)
+    {
+        _folders = _folders
+            .Where(existingFolder => !string.Equals(existingFolder.Id, folder.Id, StringComparison.Ordinal))
+            .Append(folder)
+            .OrderBy(existingFolder => existingFolder.DisplayOrder)
+            .ThenBy(existingFolder => existingFolder.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        RebuildLibraryView();
     }
 
     private string ResolveDraftParentId() =>

--- a/src/PrompterLive.Shared/Library/Pages/LibraryPage.Lifecycle.cs
+++ b/src/PrompterLive.Shared/Library/Pages/LibraryPage.Lifecycle.cs
@@ -34,11 +34,15 @@ public partial class LibraryPage
                 StateHasChanged();
             });
 
-    private async Task LoadLibraryAsync()
+    private async Task LoadLibraryAsync(bool restoreViewState = true)
     {
         await Bootstrapper.EnsureReadyAsync();
 
-        await RestoreViewStateAsync();
+        if (restoreViewState)
+        {
+            await RestoreViewStateAsync();
+        }
+
         _folders = await LibraryFolderRepository.ListAsync();
 
         var summaries = await ScriptRepository.ListAsync();

--- a/src/PrompterLive.Shared/Library/Pages/LibraryPage.ScriptActions.cs
+++ b/src/PrompterLive.Shared/Library/Pages/LibraryPage.ScriptActions.cs
@@ -63,7 +63,7 @@ public partial class LibraryPage
                     documentName: null,
                     existingId: null,
                     folderId: document.FolderId);
-                await LoadLibraryAsync();
+                await LoadLibraryAsync(restoreViewState: false);
             });
 
     private Task MoveScriptAsync(LibraryMoveRequest request) =>
@@ -74,7 +74,8 @@ public partial class LibraryPage
             {
                 await Bootstrapper.EnsureReadyAsync();
                 await ScriptRepository.MoveToFolderAsync(request.ScriptId, request.FolderId);
-                await LoadLibraryAsync();
+                ApplyMovedScript(request);
+                await PersistViewStateAsync();
             });
 
     private Task DeleteScriptAsync(string id) =>
@@ -91,6 +92,17 @@ public partial class LibraryPage
                     await SessionService.NewAsync();
                 }
 
-                await LoadLibraryAsync();
+                await LoadLibraryAsync(restoreViewState: false);
             });
+
+    private void ApplyMovedScript(LibraryMoveRequest request)
+    {
+        _allCards = _allCards
+            .Select(card => string.Equals(card.Id, request.ScriptId, StringComparison.Ordinal)
+                ? card with { FolderId = request.FolderId }
+                : card)
+            .ToList();
+
+        RebuildLibraryView();
+    }
 }

--- a/src/PrompterLive.Shared/Library/Services/Storage/BrowserLibraryFolderRepository.cs
+++ b/src/PrompterLive.Shared/Library/Services/Storage/BrowserLibraryFolderRepository.cs
@@ -13,36 +13,15 @@ public sealed class BrowserLibraryFolderRepository(IJSRuntime jsRuntime) : ILibr
     };
 
     private readonly IJSRuntime _jsRuntime = jsRuntime;
+    private IReadOnlyList<BrowserStoredLibraryFolderDto> _seedFolders = [];
 
-    public async Task InitializeAsync(IEnumerable<StoredLibraryFolder> initialFolders, CancellationToken cancellationToken = default)
+    public Task InitializeAsync(IEnumerable<StoredLibraryFolder> initialFolders, CancellationToken cancellationToken = default)
     {
-        var folders = await LoadFoldersAsync(cancellationToken);
-        var nextFolderDtos = folders
-            .Where(folder => !LegacyLibrarySeedCatalog.IsLegacyFolder(folder))
+        _seedFolders = initialFolders
+            .Select(ToDto)
             .ToList();
-        if (nextFolderDtos.Count == 0)
-        {
-            var existingIds = nextFolderDtos
-                .Select(folder => folder.Id)
-                .ToHashSet(StringComparer.Ordinal);
 
-            foreach (var folder in initialFolders.Where(folder => !existingIds.Contains(folder.Id)).Select(ToDto))
-            {
-                nextFolderDtos.Add(folder);
-            }
-        }
-
-        var shouldPersist = nextFolderDtos.Count != folders.Count ||
-            !string.Equals(
-                await LoadStorageValueAsync(BrowserStorageKeys.FolderSeedVersion, cancellationToken),
-                LegacyLibrarySeedCatalog.CleanupVersion,
-                StringComparison.Ordinal);
-
-        if (shouldPersist)
-        {
-            await SaveFoldersAsync(nextFolderDtos, cancellationToken);
-            await SaveStorageValueAsync(BrowserStorageKeys.FolderSeedVersion, LegacyLibrarySeedCatalog.CleanupVersion, cancellationToken);
-        }
+        return Task.CompletedTask;
     }
 
     public async Task<IReadOnlyList<StoredLibraryFolder>> ListAsync(CancellationToken cancellationToken = default)
@@ -75,27 +54,79 @@ public sealed class BrowserLibraryFolderRepository(IJSRuntime jsRuntime) : ILibr
             DisplayOrder: ResolveDisplayOrder(parentId, folders),
             UpdatedAt: DateTimeOffset.UtcNow);
 
-        return await SaveInternalAsync(folder, cancellationToken);
+        var mutableFolders = await LoadMutableFoldersAsync(cancellationToken);
+        UpsertFolder(mutableFolders, ToDto(folder));
+        await SaveStoredFoldersAsync(mutableFolders, cancellationToken);
+        return folder;
     }
 
-    private async Task<StoredLibraryFolder> SaveInternalAsync(
-        StoredLibraryFolder folder,
-        CancellationToken cancellationToken)
+    private async Task<List<BrowserStoredLibraryFolderDto>> LoadFoldersAsync(CancellationToken cancellationToken)
     {
-        var folders = await LoadFoldersAsync(cancellationToken);
-        var dto = ToDto(folder);
-        var existingIndex = folders.FindIndex(item => string.Equals(item.Id, dto.Id, StringComparison.Ordinal));
-        if (existingIndex >= 0)
+        var storedFolders = await LoadStoredFoldersAsync(cancellationToken);
+        if (await IsMaterializedAsync(cancellationToken))
         {
-            folders[existingIndex] = dto;
-        }
-        else
-        {
-            folders.Add(dto);
+            return storedFolders;
         }
 
-        await SaveFoldersAsync(folders, cancellationToken);
-        return MapFolder(dto);
+        return MergeFolders(
+            _seedFolders,
+            storedFolders.Where(folder => !LegacyLibrarySeedCatalog.IsLegacyFolder(folder)));
+    }
+
+    private async Task<List<BrowserStoredLibraryFolderDto>> LoadMutableFoldersAsync(CancellationToken cancellationToken)
+    {
+        var storedFolders = await LoadStoredFoldersAsync(cancellationToken);
+        if (await IsMaterializedAsync(cancellationToken))
+        {
+            return storedFolders;
+        }
+
+        var materializedFolders = MergeFolders(
+            _seedFolders,
+            storedFolders.Where(folder => !LegacyLibrarySeedCatalog.IsLegacyFolder(folder)));
+
+        await SaveStoredFoldersAsync(materializedFolders, cancellationToken);
+        return materializedFolders;
+    }
+
+    private async Task<List<BrowserStoredLibraryFolderDto>> LoadStoredFoldersAsync(CancellationToken cancellationToken)
+    {
+        var json = await _jsRuntime.InvokeAsync<string?>(
+            BrowserStorageMethodNames.LoadStorageValue,
+            cancellationToken,
+            BrowserStorageKeys.FolderLibrary);
+
+        return string.IsNullOrWhiteSpace(json)
+            ? []
+            : JsonSerializer.Deserialize<List<BrowserStoredLibraryFolderDto>>(json, JsonOptions) ?? [];
+    }
+
+    private async Task SaveStoredFoldersAsync(
+        IReadOnlyCollection<BrowserStoredLibraryFolderDto> folders,
+        CancellationToken cancellationToken)
+    {
+        var json = JsonSerializer.Serialize(folders, JsonOptions);
+        await _jsRuntime.InvokeVoidAsync(
+            BrowserStorageMethodNames.SaveStorageValue,
+            cancellationToken,
+            BrowserStorageKeys.FolderLibrary,
+            json);
+
+        await _jsRuntime.InvokeVoidAsync(
+            BrowserStorageMethodNames.SaveStorageValue,
+            cancellationToken,
+            BrowserStorageKeys.FolderSeedVersion,
+            BrowserStorageKeys.LibraryMaterializationVersion);
+    }
+
+    private async Task<bool> IsMaterializedAsync(CancellationToken cancellationToken)
+    {
+        var version = await _jsRuntime.InvokeAsync<string?>(
+            BrowserStorageMethodNames.LoadStorageValue,
+            cancellationToken,
+            BrowserStorageKeys.FolderSeedVersion);
+
+        return string.Equals(version, BrowserStorageKeys.LibraryMaterializationVersion, StringComparison.Ordinal);
     }
 
     private static BrowserStoredLibraryFolderDto ToDto(StoredLibraryFolder folder) =>
@@ -146,38 +177,40 @@ public sealed class BrowserLibraryFolderRepository(IJSRuntime jsRuntime) : ILibr
         return candidate;
     }
 
-    private async Task<List<BrowserStoredLibraryFolderDto>> LoadFoldersAsync(CancellationToken cancellationToken)
-    {
-        var json = await LoadStorageValueAsync(BrowserStorageKeys.FolderLibrary, cancellationToken);
-        return string.IsNullOrWhiteSpace(json)
-            ? []
-            : JsonSerializer.Deserialize<List<BrowserStoredLibraryFolderDto>>(json, JsonOptions) ?? [];
-    }
-
-    private Task SaveFoldersAsync(
+    private static void UpsertFolder(
         List<BrowserStoredLibraryFolderDto> folders,
-        CancellationToken cancellationToken)
+        BrowserStoredLibraryFolderDto folder)
     {
-        return SaveStorageValueAsync(
-            BrowserStorageKeys.FolderLibrary,
-            JsonSerializer.Serialize(folders, JsonOptions),
-            cancellationToken);
+        var index = folders.FindIndex(existing => string.Equals(existing.Id, folder.Id, StringComparison.Ordinal));
+        if (index >= 0)
+        {
+            folders[index] = folder;
+            return;
+        }
+
+        folders.Add(folder);
     }
 
-    private Task<string?> LoadStorageValueAsync(string key, CancellationToken cancellationToken)
+    private static List<BrowserStoredLibraryFolderDto> MergeFolders(params IEnumerable<BrowserStoredLibraryFolderDto>[] sources)
     {
-        return _jsRuntime.InvokeAsync<string?>(
-            BrowserStorageMethodNames.LoadStorageValue,
-            cancellationToken,
-            key).AsTask();
-    }
+        var foldersById = new Dictionary<string, BrowserStoredLibraryFolderDto>(StringComparer.Ordinal);
 
-    private Task SaveStorageValueAsync(string key, string value, CancellationToken cancellationToken)
-    {
-        return _jsRuntime.InvokeVoidAsync(
-            BrowserStorageMethodNames.SaveStorageValue,
-            cancellationToken,
-            key,
-            value).AsTask();
+        foreach (var source in sources)
+        {
+            foreach (var folder in source)
+            {
+                if (string.IsNullOrWhiteSpace(folder.Id))
+                {
+                    continue;
+                }
+
+                foldersById[folder.Id] = folder;
+            }
+        }
+
+        return foldersById.Values
+            .OrderBy(folder => folder.DisplayOrder)
+            .ThenBy(folder => folder.Name, StringComparer.OrdinalIgnoreCase)
+            .ToList();
     }
 }

--- a/src/PrompterLive.Shared/Library/Services/Storage/BrowserLibraryStoragePaths.cs
+++ b/src/PrompterLive.Shared/Library/Services/Storage/BrowserLibraryStoragePaths.cs
@@ -1,0 +1,19 @@
+using PrompterLive.Shared.Storage;
+
+namespace PrompterLive.Shared.Services;
+
+internal static class BrowserLibraryStoragePaths
+{
+    private const string JsonFileExtension = ".json";
+
+    public static string FolderDirectoryPath => PrompterStorageDefaults.FolderDirectoryPath;
+
+    public static string ScriptDirectoryPath => PrompterStorageDefaults.ScriptDirectoryPath;
+
+    public static string FolderFilePath(string folderId) => BuildJsonFilePath(FolderDirectoryPath, folderId);
+
+    public static string ScriptFilePath(string scriptId) => BuildJsonFilePath(ScriptDirectoryPath, scriptId);
+
+    private static string BuildJsonFilePath(string directoryPath, string itemId) =>
+        string.Concat(directoryPath, "/", itemId, JsonFileExtension);
+}

--- a/src/PrompterLive.Shared/Library/Services/Storage/BrowserScriptRepository.cs
+++ b/src/PrompterLive.Shared/Library/Services/Storage/BrowserScriptRepository.cs
@@ -13,10 +13,15 @@ public sealed class BrowserScriptRepository(IJSRuntime jsRuntime) : IScriptRepos
     };
 
     private readonly IJSRuntime _jsRuntime = jsRuntime;
+    private IReadOnlyList<BrowserStoredScriptDocumentDto> _seedDocuments = [];
 
     public Task InitializeAsync(IEnumerable<StoredScriptDocument> initialDocuments, CancellationToken cancellationToken = default)
     {
-        return InitializeDocumentsAsync(initialDocuments, cancellationToken);
+        _seedDocuments = initialDocuments
+            .Select(ToDto)
+            .ToList();
+
+        return Task.CompletedTask;
     }
 
     public async Task<IReadOnlyList<StoredScriptSummary>> ListAsync(CancellationToken cancellationToken = default)
@@ -36,9 +41,12 @@ public sealed class BrowserScriptRepository(IJSRuntime jsRuntime) : IScriptRepos
             .ToList();
     }
 
-    public Task<StoredScriptDocument?> GetAsync(string id, CancellationToken cancellationToken = default)
+    public async Task<StoredScriptDocument?> GetAsync(string id, CancellationToken cancellationToken = default)
     {
-        return GetMappedAsync(id, cancellationToken);
+        var dto = (await LoadDocumentsAsync(cancellationToken))
+            .FirstOrDefault(document => string.Equals(document.Id, id, StringComparison.Ordinal));
+
+        return dto is null ? null : ToDocument(dto);
     }
 
     public async Task<StoredScriptDocument> SaveAsync(
@@ -53,8 +61,8 @@ public sealed class BrowserScriptRepository(IJSRuntime jsRuntime) : IScriptRepos
         documentName = string.IsNullOrWhiteSpace(documentName)
             ? $"{BrowserStorageSlugifier.Slugify(title)}.tps"
             : documentName;
-        var persistedFolderId = await ResolveFolderIdAsync(existingId, folderId, cancellationToken);
 
+        var persistedFolderId = await ResolveFolderIdAsync(existingId, folderId, cancellationToken);
         var document = new StoredScriptDocument(
             Id: string.IsNullOrWhiteSpace(existingId) ? BrowserStorageSlugifier.Slugify(Path.GetFileNameWithoutExtension(documentName)) : existingId,
             Title: title,
@@ -63,120 +71,36 @@ public sealed class BrowserScriptRepository(IJSRuntime jsRuntime) : IScriptRepos
             UpdatedAt: DateTimeOffset.UtcNow,
             FolderId: persistedFolderId);
 
-        var documents = await LoadDocumentsAsync(cancellationToken);
-        var nextDocument = ToDto(document);
-        var existingIndex = documents.FindIndex(item => string.Equals(item.Id, nextDocument.Id, StringComparison.Ordinal));
-        if (existingIndex >= 0)
-        {
-            documents[existingIndex] = nextDocument;
-        }
-        else
-        {
-            documents.Add(nextDocument);
-        }
-
-        await SaveDocumentsAsync(documents, cancellationToken);
+        var documents = await LoadMutableDocumentsAsync(cancellationToken);
+        UpsertDocument(documents, ToDto(document));
+        await SaveStoredDocumentsAsync(documents, cancellationToken);
         return document;
     }
 
     public async Task MoveToFolderAsync(string id, string? folderId, CancellationToken cancellationToken = default)
     {
-        var document = await GetMappedAsync(id, cancellationToken);
-        if (document is null)
+        var documents = await LoadMutableDocumentsAsync(cancellationToken);
+        var index = documents.FindIndex(document => string.Equals(document.Id, id, StringComparison.Ordinal));
+        if (index < 0)
         {
             return;
         }
 
-        var updated = document with
-        {
-            UpdatedAt = DateTimeOffset.UtcNow,
-            FolderId = string.IsNullOrWhiteSpace(folderId) ? null : folderId
-        };
+        documents[index].FolderId = string.IsNullOrWhiteSpace(folderId) ? null : folderId;
+        documents[index].UpdatedAt = DateTimeOffset.UtcNow;
 
-        var documents = await LoadDocumentsAsync(cancellationToken);
-        var updatedDto = ToDto(updated);
-        var existingIndex = documents.FindIndex(item => string.Equals(item.Id, updatedDto.Id, StringComparison.Ordinal));
-        if (existingIndex < 0)
-        {
-            return;
-        }
-
-        documents[existingIndex] = updatedDto;
-        await SaveDocumentsAsync(documents, cancellationToken);
+        await SaveStoredDocumentsAsync(documents, cancellationToken);
     }
 
     public async Task DeleteAsync(string id, CancellationToken cancellationToken = default)
     {
-        var documents = await LoadDocumentsAsync(cancellationToken);
-        documents.RemoveAll(document => string.Equals(document.Id, id, StringComparison.Ordinal));
-        await SaveDocumentsAsync(documents, cancellationToken);
-    }
-
-    private static int CountWords(string text) =>
-        string.IsNullOrWhiteSpace(text)
-            ? 0
-            : text.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Length;
-
-    private async Task<StoredScriptDocument?> GetMappedAsync(string id, CancellationToken cancellationToken)
-    {
-        var dto = (await LoadDocumentsAsync(cancellationToken))
-            .FirstOrDefault(document => string.Equals(document.Id, id, StringComparison.Ordinal));
-        return dto is null ? null : ToDocument(dto);
-    }
-
-    private async Task InitializeDocumentsAsync(IEnumerable<StoredScriptDocument> initialDocuments, CancellationToken cancellationToken)
-    {
-        var documents = await LoadDocumentsAsync(cancellationToken);
-        var nextDocuments = documents
-            .Where(document => !LegacyLibrarySeedCatalog.IsLegacyDocument(document))
-            .ToList();
-        if (nextDocuments.Count == 0)
+        var documents = await LoadMutableDocumentsAsync(cancellationToken);
+        if (documents.RemoveAll(document => string.Equals(document.Id, id, StringComparison.Ordinal)) == 0)
         {
-            var existingIds = nextDocuments
-                .Select(document => document.Id)
-                .ToHashSet(StringComparer.Ordinal);
-
-            foreach (var document in initialDocuments.Where(document => !existingIds.Contains(document.Id)).Select(ToDto))
-            {
-                nextDocuments.Add(document);
-            }
+            return;
         }
 
-        var shouldPersist = nextDocuments.Count != documents.Count ||
-            !string.Equals(
-                await LoadStorageValueAsync(BrowserStorageKeys.DocumentSeedVersion, cancellationToken),
-                LegacyLibrarySeedCatalog.CleanupVersion,
-                StringComparison.Ordinal);
-
-        if (shouldPersist)
-        {
-            await SaveDocumentsAsync(nextDocuments, cancellationToken);
-            await SaveStorageValueAsync(BrowserStorageKeys.DocumentSeedVersion, LegacyLibrarySeedCatalog.CleanupVersion, cancellationToken);
-        }
-    }
-
-    private static StoredScriptDocument ToDocument(BrowserStoredScriptDocumentDto dto)
-    {
-        return new StoredScriptDocument(
-            dto.Id ?? string.Empty,
-            dto.Title ?? "Untitled Script",
-            dto.Text ?? string.Empty,
-            dto.DocumentName ?? "untitled-script.tps",
-            dto.UpdatedAt,
-            string.IsNullOrWhiteSpace(dto.FolderId) ? null : dto.FolderId);
-    }
-
-    private static BrowserStoredScriptDocumentDto ToDto(StoredScriptDocument document)
-    {
-        return new BrowserStoredScriptDocumentDto
-        {
-            Id = document.Id,
-            Title = document.Title,
-            Text = document.Text,
-            DocumentName = document.DocumentName,
-            UpdatedAt = document.UpdatedAt,
-            FolderId = document.FolderId
-        };
+        await SaveStoredDocumentsAsync(documents, cancellationToken);
     }
 
     private async Task<string?> ResolveFolderIdAsync(
@@ -194,43 +118,137 @@ public sealed class BrowserScriptRepository(IJSRuntime jsRuntime) : IScriptRepos
             return null;
         }
 
-        var existingDocument = await GetMappedAsync(existingId, cancellationToken);
+        var existingDocument = await GetAsync(existingId, cancellationToken);
         return existingDocument?.FolderId;
     }
 
     private async Task<List<BrowserStoredScriptDocumentDto>> LoadDocumentsAsync(CancellationToken cancellationToken)
     {
-        var json = await LoadStorageValueAsync(BrowserStorageKeys.DocumentLibrary, cancellationToken);
+        var storedDocuments = await LoadStoredDocumentsAsync(cancellationToken);
+        if (await IsMaterializedAsync(cancellationToken))
+        {
+            return storedDocuments;
+        }
+
+        return MergeDocuments(
+            _seedDocuments,
+            storedDocuments.Where(document => !LegacyLibrarySeedCatalog.IsLegacyDocument(document)));
+    }
+
+    private async Task<List<BrowserStoredScriptDocumentDto>> LoadMutableDocumentsAsync(CancellationToken cancellationToken)
+    {
+        var storedDocuments = await LoadStoredDocumentsAsync(cancellationToken);
+        if (await IsMaterializedAsync(cancellationToken))
+        {
+            return storedDocuments;
+        }
+
+        var materializedDocuments = MergeDocuments(
+            _seedDocuments,
+            storedDocuments.Where(document => !LegacyLibrarySeedCatalog.IsLegacyDocument(document)));
+
+        await SaveStoredDocumentsAsync(materializedDocuments, cancellationToken);
+        return materializedDocuments;
+    }
+
+    private async Task<List<BrowserStoredScriptDocumentDto>> LoadStoredDocumentsAsync(CancellationToken cancellationToken)
+    {
+        var json = await _jsRuntime.InvokeAsync<string?>(
+            BrowserStorageMethodNames.LoadStorageValue,
+            cancellationToken,
+            BrowserStorageKeys.DocumentLibrary);
+
         return string.IsNullOrWhiteSpace(json)
             ? []
             : JsonSerializer.Deserialize<List<BrowserStoredScriptDocumentDto>>(json, JsonOptions) ?? [];
     }
 
-    private Task SaveDocumentsAsync(
-        List<BrowserStoredScriptDocumentDto> documents,
+    private async Task SaveStoredDocumentsAsync(
+        IReadOnlyCollection<BrowserStoredScriptDocumentDto> documents,
         CancellationToken cancellationToken)
     {
-        return SaveStorageValueAsync(
-            BrowserStorageKeys.DocumentLibrary,
-            JsonSerializer.Serialize(documents, JsonOptions),
-            cancellationToken);
-    }
-
-    private Task<string?> LoadStorageValueAsync(string key, CancellationToken cancellationToken)
-    {
-        return _jsRuntime.InvokeAsync<string?>(
-            BrowserStorageMethodNames.LoadStorageValue,
-            cancellationToken,
-            key).AsTask();
-    }
-
-    private Task SaveStorageValueAsync(string key, string value, CancellationToken cancellationToken)
-    {
-        return _jsRuntime.InvokeVoidAsync(
+        var json = JsonSerializer.Serialize(documents, JsonOptions);
+        await _jsRuntime.InvokeVoidAsync(
             BrowserStorageMethodNames.SaveStorageValue,
             cancellationToken,
-            key,
-            value).AsTask();
+            BrowserStorageKeys.DocumentLibrary,
+            json);
+
+        await _jsRuntime.InvokeVoidAsync(
+            BrowserStorageMethodNames.SaveStorageValue,
+            cancellationToken,
+            BrowserStorageKeys.DocumentSeedVersion,
+            BrowserStorageKeys.LibraryMaterializationVersion);
     }
 
+    private async Task<bool> IsMaterializedAsync(CancellationToken cancellationToken)
+    {
+        var version = await _jsRuntime.InvokeAsync<string?>(
+            BrowserStorageMethodNames.LoadStorageValue,
+            cancellationToken,
+            BrowserStorageKeys.DocumentSeedVersion);
+
+        return string.Equals(version, BrowserStorageKeys.LibraryMaterializationVersion, StringComparison.Ordinal);
+    }
+
+    private static void UpsertDocument(
+        List<BrowserStoredScriptDocumentDto> documents,
+        BrowserStoredScriptDocumentDto document)
+    {
+        var index = documents.FindIndex(existing => string.Equals(existing.Id, document.Id, StringComparison.Ordinal));
+        if (index >= 0)
+        {
+            documents[index] = document;
+            return;
+        }
+
+        documents.Add(document);
+    }
+
+    private static int CountWords(string text) =>
+        string.IsNullOrWhiteSpace(text)
+            ? 0
+            : text.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).Length;
+
+    private static StoredScriptDocument ToDocument(BrowserStoredScriptDocumentDto dto) =>
+        new(
+            dto.Id ?? string.Empty,
+            dto.Title ?? "Untitled Script",
+            dto.Text ?? string.Empty,
+            dto.DocumentName ?? "untitled-script.tps",
+            dto.UpdatedAt,
+            string.IsNullOrWhiteSpace(dto.FolderId) ? null : dto.FolderId);
+
+    private static BrowserStoredScriptDocumentDto ToDto(StoredScriptDocument document) =>
+        new()
+        {
+            Id = document.Id,
+            Title = document.Title,
+            Text = document.Text,
+            DocumentName = document.DocumentName,
+            UpdatedAt = document.UpdatedAt,
+            FolderId = document.FolderId
+        };
+
+    private static List<BrowserStoredScriptDocumentDto> MergeDocuments(params IEnumerable<BrowserStoredScriptDocumentDto>[] sources)
+    {
+        var documentsById = new Dictionary<string, BrowserStoredScriptDocumentDto>(StringComparer.Ordinal);
+
+        foreach (var source in sources)
+        {
+            foreach (var document in source)
+            {
+                if (string.IsNullOrWhiteSpace(document.Id))
+                {
+                    continue;
+                }
+
+                documentsById[document.Id] = document;
+            }
+        }
+
+        return documentsById.Values
+            .OrderByDescending(document => document.UpdatedAt)
+            .ToList();
+    }
 }

--- a/src/PrompterLive.Shared/Library/Services/Storage/BrowserStorageKeys.cs
+++ b/src/PrompterLive.Shared/Library/Services/Storage/BrowserStorageKeys.cs
@@ -6,6 +6,7 @@ public static class BrowserStorageKeys
     public const string DocumentSeedVersion = "prompterlive.library.seed-version";
     public const string FolderLibrary = "prompterlive.folders.v1";
     public const string FolderSeedVersion = "prompterlive.folders.seed-version";
+    public const string LibraryMaterializationVersion = "2026-04-01-browser-library-materialized-v1";
     public const string SettingsPrefix = "prompterlive.settings.";
     public const string CultureSetting = SettingsPrefix + "culture";
 }

--- a/src/PrompterLive.Shared/Library/Services/Storage/LegacyLibrarySeedCatalog.cs
+++ b/src/PrompterLive.Shared/Library/Services/Storage/LegacyLibrarySeedCatalog.cs
@@ -14,16 +14,6 @@ internal static class LegacyLibrarySeedCatalog
         "comprehensive-demo"
     };
 
-    private static readonly HashSet<string> LegacyDocumentNames = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "test-script.tps",
-        "ted-leadership.tps",
-        "security-incident.tps",
-        "green-architecture.tps",
-        "quantum-computing.tps",
-        "comprehensive-demo.tps"
-    };
-
     private static readonly HashSet<string> LegacyFolderIds = new(StringComparer.Ordinal)
     {
         "presentations",
@@ -37,8 +27,7 @@ internal static class LegacyLibrarySeedCatalog
 
     public static bool IsLegacyDocument(BrowserStoredScriptDocumentDto document)
     {
-        return LegacyDocumentIds.Contains(document.Id ?? string.Empty) ||
-               LegacyDocumentNames.Contains(document.DocumentName ?? string.Empty);
+        return LegacyDocumentIds.Contains(document.Id ?? string.Empty);
     }
 
     public static bool IsLegacyFolder(BrowserStoredLibraryFolderDto folder)

--- a/src/PrompterLive.Shared/PrompterLive.Shared.csproj
+++ b/src/PrompterLive.Shared/PrompterLive.Shared.csproj
@@ -5,6 +5,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" />
+    <PackageReference Include="ManagedCode.Storage.Browser" />
+    <PackageReference Include="ManagedCode.Storage.CloudKit" />
+    <PackageReference Include="ManagedCode.Storage.Dropbox" />
+    <PackageReference Include="ManagedCode.Storage.Gcp" />
+    <PackageReference Include="ManagedCode.Storage.GoogleDrive" />
+    <PackageReference Include="ManagedCode.Storage.OneDrive" />
+    <PackageReference Include="ManagedCode.Storage.VirtualFileSystem" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
     <PackageReference Include="Microsoft.Extensions.Localization" />
   </ItemGroup>

--- a/src/PrompterLive.Shared/Properties/AssemblyInfo.cs
+++ b/src/PrompterLive.Shared/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("PrompterLive.App.Tests")]

--- a/src/PrompterLive.Shared/Settings/Components/SettingsCloudSection.razor
+++ b/src/PrompterLive.Shared/Settings/Components/SettingsCloudSection.razor
@@ -1,110 +1,273 @@
 @namespace PrompterLive.Shared.Components.Settings
+@using ManagedCode.Storage.CloudKit.Options
+@using PrompterLive.Shared.Storage.Cloud
 
 <section class="set-section set-panel"
          id="set-cloud"
          style="@DisplayStyle"
          data-testid="@UiTestIds.Settings.CloudPanel">
     <h3 class="set-section-title">Cloud Storage</h3>
-    <p class="set-section-desc">Connect cloud accounts to sync your scripts across devices.</p>
+    <p class="set-section-desc">Connect ManagedCode storage providers to import or save scripts and settings. Provider keys stay in this browser local storage.</p>
+
+    <div class="set-subsection" style="margin-bottom:16px">
+        <h4 class="set-sub-title">Sync Defaults</h4>
+        <div class="set-device-fields">
+            <div class="set-field">
+                <label>Default provider</label>
+                <select class="set-select"
+                        value="@_preferences.PrimaryProviderId"
+                        @onchange="OnPrimaryProviderChangedAsync"
+                        data-testid="@UiTestIds.Settings.CloudDefaultProvider">
+                    <option value="@CloudStorageProviderIds.OneDrive">OneDrive</option>
+                    <option value="@CloudStorageProviderIds.GoogleDrive">Google Drive</option>
+                    <option value="@CloudStorageProviderIds.Dropbox">Dropbox</option>
+                    <option value="@CloudStorageProviderIds.GoogleCloudStorage">Google Cloud Storage</option>
+                    <option value="@CloudStorageProviderIds.CloudKit">CloudKit</option>
+                </select>
+            </div>
+            <div class="set-field set-field-toggle">
+                <label>Auto-sync on save</label>
+                <div class="@BuildToggleCssClass(_preferences.AutoSyncOnSave)"
+                     @onclick="ToggleAutoSyncOnSaveAsync"
+                     data-testid="@UiTestIds.Settings.CloudAutoSyncOnSave">
+                    <div class="set-toggle-thumb"></div>
+                </div>
+            </div>
+            <div class="set-field set-field-toggle">
+                <label>Sync on startup</label>
+                <div class="@BuildToggleCssClass(_preferences.SyncOnStartup)"
+                     @onclick="ToggleSyncOnStartupAsync"
+                     data-testid="@UiTestIds.Settings.CloudSyncOnStartup">
+                    <div class="set-toggle-thumb"></div>
+                </div>
+            </div>
+        </div>
+        <p class="set-card-copy">Local scripts and folders live in the browser storage virtual file system. Only provider credentials are persisted in browser local storage.</p>
+    </div>
 
     <div class="set-device-list">
         <SettingsExpandableCard Title="OneDrive"
-                                Subtitle="user@outlook.com"
-                                StatusLabel="Connected"
-                                StatusClass="set-dest-ok"
+                                Subtitle="@GetSubtitle(_preferences.OneDrive.Connection)"
+                                SubtitleTestId="@UiTestIds.Settings.CloudProviderSubtitle(CloudStorageProviderIds.OneDrive)"
+                                StatusLabel="@GetStatusLabel(_preferences.OneDrive.Connection)"
+                                StatusClass="@GetStatusClass(_preferences.OneDrive.Connection)"
                                 IconStyle="background:rgba(0,120,212,.15); color:#4BA3E3;"
-                                IsOpen="@IsCardOpen(OneDriveCardId)"
-                                OnToggle="@(() => ToggleCard.InvokeAsync(OneDriveCardId))">
+                                IsOpen="@IsCardOpen(CloudStorageProviderIds.OneDrive)"
+                                TestId="@UiTestIds.Settings.CloudProviderCard(CloudStorageProviderIds.OneDrive)"
+                                OnToggle="@(() => ToggleCard.InvokeAsync(CloudStorageProviderIds.OneDrive))">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M12.5 6c-1.8 0-3.4.8-4.5 2.1C7.3 7.4 6.2 7 5 7 2.2 7 0 9.2 0 12s2.2 5 5 5h14c2.8 0 5-2.2 5-5 0-2.5-1.8-4.5-4.2-4.9C18.7 5.2 16.8 4 14.5 4c-.7 0-1.4.1-2 .3V6z" />
             </svg>
             <div class="set-device-fields">
                 <div class="set-field">
-                    <label>Sync Folder</label>
-                    <div class="set-path-field">
-                        <input type="text"
-                               class="set-input"
-                               value="@OneDriveSyncFolder"
-                               @oninput="OnFolderChanged" />
-                        <button class="set-btn-outline set-btn-sm" type="button">Browse</button>
-                    </div>
+                    <label>Account Label</label>
+                    <input type="text" class="set-input" @bind="_preferences.OneDrive.Connection.AccountLabel" data-testid="@UiTestIds.Settings.CloudProviderField(CloudStorageProviderIds.OneDrive, CloudStorageFieldIds.AccountLabel)" />
                 </div>
-                <div class="set-field set-field-toggle">
-                    <label>Auto-sync on save</label>
-                    <div class="set-toggle @(CloudAutoSyncOnSave ? "on" : null)"
-                         @onclick="ToggleAutoSyncOnSave"
-                         @onclick:stopPropagation="true">
-                        <div class="set-toggle-thumb"></div>
-                    </div>
+                <div class="set-field">
+                    <label>Tenant ID</label>
+                    <input type="text" class="set-input" @bind="_oneDriveCredentials.TenantId" data-testid="@UiTestIds.Settings.CloudProviderField(CloudStorageProviderIds.OneDrive, CloudStorageFieldIds.TenantId)" />
                 </div>
-                <div class="set-field set-field-toggle">
-                    <label>Sync on startup</label>
-                    <div class="set-toggle @(CloudSyncOnStartup ? "on" : null)"
-                         @onclick="ToggleSyncOnStartup"
-                         @onclick:stopPropagation="true">
-                        <div class="set-toggle-thumb"></div>
-                    </div>
+                <div class="set-field">
+                    <label>Client ID</label>
+                    <input type="text" class="set-input" @bind="_oneDriveCredentials.ClientId" data-testid="@UiTestIds.Settings.CloudProviderField(CloudStorageProviderIds.OneDrive, CloudStorageFieldIds.ClientId)" />
+                </div>
+                <div class="set-field">
+                    <label>Client Secret</label>
+                    <input type="password" class="set-input" @bind="_oneDriveCredentials.ClientSecret" data-testid="@UiTestIds.Settings.CloudProviderField(CloudStorageProviderIds.OneDrive, CloudStorageFieldIds.ClientSecret)" />
+                </div>
+                <div class="set-field">
+                    <label>Drive ID</label>
+                    <input type="text" class="set-input" @bind="_preferences.OneDrive.DriveId" data-testid="@UiTestIds.Settings.CloudProviderField(CloudStorageProviderIds.OneDrive, CloudStorageFieldIds.DriveId)" />
+                </div>
+                <div class="set-field">
+                    <label>Root Path</label>
+                    <input type="text" class="set-input" @bind="_preferences.OneDrive.Connection.RootPath" data-testid="@UiTestIds.Settings.CloudProviderField(CloudStorageProviderIds.OneDrive, CloudStorageFieldIds.RootPath)" />
                 </div>
             </div>
-            <button class="set-btn-outline set-btn-sm set-danger-action"
-                    type="button"
-                    @onclick:stopPropagation="true">
-                Disconnect
-            </button>
+            @ProviderActions(CloudStorageProviderIds.OneDrive)
         </SettingsExpandableCard>
 
         <SettingsExpandableCard Title="Google Drive"
-                                Subtitle="Not connected"
-                                StatusLabel="Disconnected"
+                                Subtitle="@GetSubtitle(_preferences.GoogleDrive.Connection)"
+                                SubtitleTestId="@UiTestIds.Settings.CloudProviderSubtitle(CloudStorageProviderIds.GoogleDrive)"
+                                StatusLabel="@GetStatusLabel(_preferences.GoogleDrive.Connection)"
+                                StatusClass="@GetStatusClass(_preferences.GoogleDrive.Connection)"
                                 IconStyle="background:rgba(66,133,244,.12); color:#4285F4;"
-                                IsOpen="@IsCardOpen(GoogleDriveCardId)"
-                                OnToggle="@(() => ToggleCard.InvokeAsync(GoogleDriveCardId))">
+                                IsOpen="@IsCardOpen(CloudStorageProviderIds.GoogleDrive)"
+                                TestId="@UiTestIds.Settings.CloudProviderCard(CloudStorageProviderIds.GoogleDrive)"
+                                OnToggle="@(() => ToggleCard.InvokeAsync(CloudStorageProviderIds.GoogleDrive))">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M7.71 3.5L1.15 15l3.43 5.96h6.86L18 15 11.44 3.5H7.71zm.86 1.73L13 13.5H4.59l4-8.27z" />
                 <path d="M22.85 15L16.29 3.5h-3.43L19.43 15l-3.43 5.96h6.86L22.85 15z" opacity=".6" />
             </svg>
-            <p class="set-card-copy">Sign in with your Google account to sync scripts to Google Drive.</p>
-            <button class="set-btn-golden set-card-cta" type="button" @onclick:stopPropagation="true">Connect with Google</button>
+            <div class="set-device-fields">
+                <div class="set-field">
+                    <label>Account Label</label>
+                    <input type="text" class="set-input" @bind="_preferences.GoogleDrive.Connection.AccountLabel" data-testid="@UiTestIds.Settings.CloudProviderField(CloudStorageProviderIds.GoogleDrive, CloudStorageFieldIds.AccountLabel)" />
+                </div>
+                <div class="set-field">
+                    <label>Root Folder ID</label>
+                    <input type="text" class="set-input" @bind="_preferences.GoogleDrive.RootFolderId" data-testid="@UiTestIds.Settings.CloudProviderField(CloudStorageProviderIds.GoogleDrive, CloudStorageFieldIds.RootFolderId)" />
+                </div>
+                <div class="set-field">
+                    <label>Root Path</label>
+                    <input type="text" class="set-input" @bind="_preferences.GoogleDrive.Connection.RootPath" data-testid="@UiTestIds.Settings.CloudProviderField(CloudStorageProviderIds.GoogleDrive, CloudStorageFieldIds.RootPath)" />
+                </div>
+                <div class="set-field set-field-toggle">
+                    <label>Support shared drives</label>
+                    <div class="@BuildToggleCssClass(_preferences.GoogleDrive.SupportsAllDrives)"
+                         @onclick="ToggleGoogleDriveAllDrivesAsync"
+                         data-testid="@UiTestIds.Settings.CloudProviderField(CloudStorageProviderIds.GoogleDrive, CloudStorageFieldIds.SupportsAllDrives)">
+                        <div class="set-toggle-thumb"></div>
+                    </div>
+                </div>
+                <div class="set-field">
+                    <label>Service Account JSON</label>
+                    <textarea class="set-input" rows="6" @bind="_googleDriveCredentials.ServiceAccountJson" data-testid="@UiTestIds.Settings.CloudProviderField(CloudStorageProviderIds.GoogleDrive, CloudStorageFieldIds.ServiceAccountJson)"></textarea>
+                </div>
+            </div>
+            @ProviderActions(CloudStorageProviderIds.GoogleDrive)
         </SettingsExpandableCard>
 
         <SettingsExpandableCard Title="Dropbox"
-                                Subtitle="Not connected"
-                                StatusLabel="Disconnected"
+                                Subtitle="@GetSubtitle(_preferences.Dropbox.Connection)"
+                                SubtitleTestId="@UiTestIds.Settings.CloudProviderSubtitle(CloudStorageProviderIds.Dropbox)"
+                                StatusLabel="@GetStatusLabel(_preferences.Dropbox.Connection)"
+                                StatusClass="@GetStatusClass(_preferences.Dropbox.Connection)"
                                 IconStyle="background:rgba(0,97,255,.12); color:#0061FF;"
-                                IsOpen="@IsCardOpen(DropboxCardId)"
-                                OnToggle="@(() => ToggleCard.InvokeAsync(DropboxCardId))">
+                                IsOpen="@IsCardOpen(CloudStorageProviderIds.Dropbox)"
+                                TestId="@UiTestIds.Settings.CloudProviderCard(CloudStorageProviderIds.Dropbox)"
+                                OnToggle="@(() => ToggleCard.InvokeAsync(CloudStorageProviderIds.Dropbox))">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M12 2L6 6.5 12 11l-6 4.5L12 20l6-4.5L12 11l6-4.5L12 2z" />
             </svg>
-            <p class="set-card-copy">Connect Dropbox to automatically back up and sync your scripts.</p>
-            <button class="set-btn-golden set-card-cta" type="button" @onclick:stopPropagation="true">Connect with Dropbox</button>
+            <div class="set-device-fields">
+                <div class="set-field">
+                    <label>Account Label</label>
+                    <input type="text" class="set-input" @bind="_preferences.Dropbox.Connection.AccountLabel" data-testid="@UiTestIds.Settings.CloudProviderField(CloudStorageProviderIds.Dropbox, CloudStorageFieldIds.AccountLabel)" />
+                </div>
+                <div class="set-field">
+                    <label>Root Path</label>
+                    <input type="text" class="set-input" @bind="_preferences.Dropbox.Connection.RootPath" data-testid="@UiTestIds.Settings.CloudProviderField(CloudStorageProviderIds.Dropbox, CloudStorageFieldIds.RootPath)" />
+                </div>
+                <div class="set-field">
+                    <label>Access Token</label>
+                    <input type="password" class="set-input" @bind="_dropboxCredentials.AccessToken" data-testid="@UiTestIds.Settings.CloudProviderField(CloudStorageProviderIds.Dropbox, CloudStorageFieldIds.AccessToken)" />
+                </div>
+                <div class="set-field">
+                    <label>Refresh Token</label>
+                    <input type="password" class="set-input" @bind="_dropboxCredentials.RefreshToken" data-testid="@UiTestIds.Settings.CloudProviderField(CloudStorageProviderIds.Dropbox, CloudStorageFieldIds.RefreshToken)" />
+                </div>
+                <div class="set-field">
+                    <label>App Key</label>
+                    <input type="text" class="set-input" @bind="_dropboxCredentials.AppKey" data-testid="@UiTestIds.Settings.CloudProviderField(CloudStorageProviderIds.Dropbox, CloudStorageFieldIds.AppKey)" />
+                </div>
+                <div class="set-field">
+                    <label>App Secret</label>
+                    <input type="password" class="set-input" @bind="_dropboxCredentials.AppSecret" data-testid="@UiTestIds.Settings.CloudProviderField(CloudStorageProviderIds.Dropbox, CloudStorageFieldIds.AppSecret)" />
+                </div>
+            </div>
+            @ProviderActions(CloudStorageProviderIds.Dropbox)
+        </SettingsExpandableCard>
+
+        <SettingsExpandableCard Title="Google Cloud Storage"
+                                Subtitle="@GetSubtitle(_preferences.GoogleCloudStorage.Connection)"
+                                SubtitleTestId="@UiTestIds.Settings.CloudProviderSubtitle(CloudStorageProviderIds.GoogleCloudStorage)"
+                                StatusLabel="@GetStatusLabel(_preferences.GoogleCloudStorage.Connection)"
+                                StatusClass="@GetStatusClass(_preferences.GoogleCloudStorage.Connection)"
+                                IconStyle="background:rgba(34,197,94,.12); color:#4ADE80;"
+                                IsOpen="@IsCardOpen(CloudStorageProviderIds.GoogleCloudStorage)"
+                                TestId="@UiTestIds.Settings.CloudProviderCard(CloudStorageProviderIds.GoogleCloudStorage)"
+                                OnToggle="@(() => ToggleCard.InvokeAsync(CloudStorageProviderIds.GoogleCloudStorage))">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 3l8 4.5v9L12 21l-8-4.5v-9L12 3zm0 2.3L6 8.1v7.8l6 3.4 6-3.4V8.1L12 5.3z" />
+            </svg>
+            <div class="set-device-fields">
+                <div class="set-field">
+                    <label>Account Label</label>
+                    <input type="text" class="set-input" @bind="_preferences.GoogleCloudStorage.Connection.AccountLabel" data-testid="@UiTestIds.Settings.CloudProviderField(CloudStorageProviderIds.GoogleCloudStorage, CloudStorageFieldIds.AccountLabel)" />
+                </div>
+                <div class="set-field">
+                    <label>Project ID</label>
+                    <input type="text" class="set-input" @bind="_preferences.GoogleCloudStorage.ProjectId" data-testid="@UiTestIds.Settings.CloudProviderField(CloudStorageProviderIds.GoogleCloudStorage, CloudStorageFieldIds.ProjectId)" />
+                </div>
+                <div class="set-field">
+                    <label>Bucket Name</label>
+                    <input type="text" class="set-input" @bind="_preferences.GoogleCloudStorage.BucketName" data-testid="@UiTestIds.Settings.CloudProviderField(CloudStorageProviderIds.GoogleCloudStorage, CloudStorageFieldIds.BucketName)" />
+                </div>
+                <div class="set-field">
+                    <label>Root Path</label>
+                    <input type="text" class="set-input" @bind="_preferences.GoogleCloudStorage.Connection.RootPath" data-testid="@UiTestIds.Settings.CloudProviderField(CloudStorageProviderIds.GoogleCloudStorage, CloudStorageFieldIds.RootPath)" />
+                </div>
+                <div class="set-field">
+                    <label>Service Account JSON</label>
+                    <textarea class="set-input" rows="6" @bind="_googleCloudStorageCredentials.ServiceAccountJson" data-testid="@UiTestIds.Settings.CloudProviderField(CloudStorageProviderIds.GoogleCloudStorage, CloudStorageFieldIds.ServiceAccountJson)"></textarea>
+                </div>
+            </div>
+            @ProviderActions(CloudStorageProviderIds.GoogleCloudStorage)
+        </SettingsExpandableCard>
+
+        <SettingsExpandableCard Title="CloudKit"
+                                Subtitle="@GetSubtitle(_preferences.CloudKit.Connection)"
+                                SubtitleTestId="@UiTestIds.Settings.CloudProviderSubtitle(CloudStorageProviderIds.CloudKit)"
+                                StatusLabel="@GetStatusLabel(_preferences.CloudKit.Connection)"
+                                StatusClass="@GetStatusClass(_preferences.CloudKit.Connection)"
+                                IconStyle="background:rgba(244,114,182,.12); color:#F472B6;"
+                                IsOpen="@IsCardOpen(CloudStorageProviderIds.CloudKit)"
+                                TestId="@UiTestIds.Settings.CloudProviderCard(CloudStorageProviderIds.CloudKit)"
+                                OnToggle="@(() => ToggleCard.InvokeAsync(CloudStorageProviderIds.CloudKit))">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M12 2a7 7 0 0 1 7 7c0 2.1-.95 4.15-2.58 5.5L12 22l-4.42-7.5A6.95 6.95 0 0 1 5 9a7 7 0 0 1 7-7zm0 3a4 4 0 0 0-4 4c0 1.15.48 2.25 1.31 3.01L12 16.5l2.69-4.49A4.01 4.01 0 0 0 16 9a4 4 0 0 0-4-4z" />
+            </svg>
+            <div class="set-device-fields">
+                <div class="set-field">
+                    <label>Account Label</label>
+                    <input type="text" class="set-input" @bind="_preferences.CloudKit.Connection.AccountLabel" data-testid="@UiTestIds.Settings.CloudProviderField(CloudStorageProviderIds.CloudKit, CloudStorageFieldIds.AccountLabel)" />
+                </div>
+                <div class="set-field">
+                    <label>Container ID</label>
+                    <input type="text" class="set-input" @bind="_preferences.CloudKit.ContainerId" data-testid="@UiTestIds.Settings.CloudProviderField(CloudStorageProviderIds.CloudKit, CloudStorageFieldIds.ContainerId)" />
+                </div>
+                <div class="set-field">
+                    <label>Root Path</label>
+                    <input type="text" class="set-input" @bind="_preferences.CloudKit.Connection.RootPath" data-testid="@UiTestIds.Settings.CloudProviderField(CloudStorageProviderIds.CloudKit, CloudStorageFieldIds.RootPath)" />
+                </div>
+                <div class="set-field">
+                    <label>Environment</label>
+                    <select class="set-select" @bind="_preferences.CloudKit.Environment" data-testid="@UiTestIds.Settings.CloudProviderField(CloudStorageProviderIds.CloudKit, CloudStorageFieldIds.Environment)">
+                        @foreach (var environment in CloudKitEnvironments)
+                        {
+                            <option value="@environment">@environment</option>
+                        }
+                    </select>
+                </div>
+                <div class="set-field">
+                    <label>Database</label>
+                    <select class="set-select" @bind="_preferences.CloudKit.Database" data-testid="@UiTestIds.Settings.CloudProviderField(CloudStorageProviderIds.CloudKit, CloudStorageFieldIds.Database)">
+                        @foreach (var database in CloudKitDatabases)
+                        {
+                            <option value="@database">@database</option>
+                        }
+                    </select>
+                </div>
+                <div class="set-field">
+                    <label>API Token</label>
+                    <input type="password" class="set-input" @bind="_cloudKitCredentials.ApiToken" data-testid="@UiTestIds.Settings.CloudProviderField(CloudStorageProviderIds.CloudKit, CloudStorageFieldIds.ApiToken)" />
+                </div>
+                <div class="set-field">
+                    <label>Web Auth Token</label>
+                    <input type="password" class="set-input" @bind="_cloudKitCredentials.WebAuthToken" data-testid="@UiTestIds.Settings.CloudProviderField(CloudStorageProviderIds.CloudKit, CloudStorageFieldIds.WebAuthToken)" />
+                </div>
+                <div class="set-field">
+                    <label>Server-to-Server Key ID</label>
+                    <input type="text" class="set-input" @bind="_cloudKitCredentials.ServerToServerKeyId" data-testid="@UiTestIds.Settings.CloudProviderField(CloudStorageProviderIds.CloudKit, CloudStorageFieldIds.ServerToServerKeyId)" />
+                </div>
+                <div class="set-field">
+                    <label>Server Private Key PEM</label>
+                    <textarea class="set-input" rows="6" @bind="_cloudKitCredentials.ServerToServerPrivateKeyPem" data-testid="@UiTestIds.Settings.CloudProviderField(CloudStorageProviderIds.CloudKit, CloudStorageFieldIds.ServerPrivateKeyPem)"></textarea>
+                </div>
+            </div>
+            @ProviderActions(CloudStorageProviderIds.CloudKit)
         </SettingsExpandableCard>
     </div>
 </section>
-
-@code {
-    private const string DropboxCardId = "cloud-dropbox";
-    private const string GoogleDriveCardId = "cloud-google-drive";
-    private const string OneDriveCardId = "cloud-onedrive";
-
-    [Parameter] public bool CloudAutoSyncOnSave { get; set; }
-
-    [Parameter] public bool CloudSyncOnStartup { get; set; }
-
-    [Parameter] public string DisplayStyle { get; set; } = string.Empty;
-
-    [Parameter] public Func<string, bool> IsCardOpen { get; set; } = static _ => false;
-
-    [Parameter] public string OneDriveSyncFolder { get; set; } = string.Empty;
-
-    [Parameter] public EventCallback<string> OneDriveSyncFolderChanged { get; set; }
-
-    [Parameter] public EventCallback ToggleAutoSyncOnSave { get; set; }
-
-    [Parameter] public EventCallback<string> ToggleCard { get; set; }
-
-    [Parameter] public EventCallback ToggleSyncOnStartup { get; set; }
-
-    private Task OnFolderChanged(ChangeEventArgs args) =>
-        OneDriveSyncFolderChanged.InvokeAsync(args.Value?.ToString() ?? string.Empty);
-}

--- a/src/PrompterLive.Shared/Settings/Components/SettingsCloudSection.razor.cs
+++ b/src/PrompterLive.Shared/Settings/Components/SettingsCloudSection.razor.cs
@@ -1,0 +1,250 @@
+using ManagedCode.Storage.CloudKit.Options;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
+using PrompterLive.Shared.Contracts;
+using PrompterLive.Shared.Storage.Cloud;
+
+namespace PrompterLive.Shared.Components.Settings;
+
+public partial class SettingsCloudSection : ComponentBase
+{
+    private const string ConnectedStatusClass = "set-dest-ok";
+    private const string ConnectedStatusLabel = "Connected";
+    private const string DisconnectedSubtitle = "Not connected";
+    private const string DisconnectedStatusLabel = "Disconnected";
+    private const string OnCssClass = "on";
+    private const string SetToggleCssClass = "set-toggle";
+
+    private CloudStoragePreferences _preferences = CloudStoragePreferences.CreateDefault();
+    private DropboxCloudStorageCredentials _dropboxCredentials = new();
+    private OneDriveCloudStorageCredentials _oneDriveCredentials = new();
+    private GoogleDriveCloudStorageCredentials _googleDriveCredentials = new();
+    private GoogleCloudStorageCredentials _googleCloudStorageCredentials = new();
+    private CloudKitStorageCredentials _cloudKitCredentials = new();
+    private readonly Dictionary<string, string> _providerMessages = new(StringComparer.Ordinal);
+
+    [Inject] private BrowserCloudStorageStore CloudStorageStore { get; set; } = null!;
+
+    [Inject] private CloudStorageProviderFactory CloudStorageProviderFactory { get; set; } = null!;
+
+    [Inject] private CloudStorageTransferService CloudStorageTransferService { get; set; } = null!;
+
+    [Parameter] public string DisplayStyle { get; set; } = string.Empty;
+
+    [Parameter] public Func<string, bool> IsCardOpen { get; set; } = static _ => false;
+
+    [Parameter] public EventCallback SettingsImported { get; set; }
+
+    [Parameter] public EventCallback<string> ToggleCard { get; set; }
+
+    private static IReadOnlyList<CloudKitDatabase> CloudKitDatabases { get; } = Enum.GetValues<CloudKitDatabase>();
+
+    private static IReadOnlyList<CloudKitEnvironment> CloudKitEnvironments { get; } = Enum.GetValues<CloudKitEnvironment>();
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender)
+        {
+            return;
+        }
+
+        await LoadStateAsync();
+        await EnsureProviderCardOpenAsync(_preferences.PrimaryProviderId);
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task LoadStateAsync()
+    {
+        _preferences = await CloudStorageStore.LoadPreferencesAsync();
+        _dropboxCredentials = await CloudStorageStore.LoadDropboxCredentialsAsync();
+        _oneDriveCredentials = await CloudStorageStore.LoadOneDriveCredentialsAsync();
+        _googleDriveCredentials = await CloudStorageStore.LoadGoogleDriveCredentialsAsync();
+        _googleCloudStorageCredentials = await CloudStorageStore.LoadGoogleCloudStorageCredentialsAsync();
+        _cloudKitCredentials = await CloudStorageStore.LoadCloudKitCredentialsAsync();
+    }
+
+    private async Task OnPrimaryProviderChangedAsync(ChangeEventArgs args)
+    {
+        _preferences.PrimaryProviderId = args.Value?.ToString() ?? CloudStorageProviderIds.OneDrive;
+        await PersistPreferencesAsync();
+        await EnsureProviderCardOpenAsync(_preferences.PrimaryProviderId);
+    }
+
+    private async Task ToggleAutoSyncOnSaveAsync()
+    {
+        _preferences.AutoSyncOnSave = !_preferences.AutoSyncOnSave;
+        await PersistPreferencesAsync();
+    }
+
+    private async Task ToggleSyncOnStartupAsync()
+    {
+        _preferences.SyncOnStartup = !_preferences.SyncOnStartup;
+        await PersistPreferencesAsync();
+    }
+
+    private async Task ToggleGoogleDriveAllDrivesAsync()
+    {
+        _preferences.GoogleDrive.SupportsAllDrives = !_preferences.GoogleDrive.SupportsAllDrives;
+        await PersistPreferencesAsync();
+    }
+
+    private async Task SaveAndValidateAsync(string providerId)
+    {
+        await PersistProviderAsync(providerId);
+        var result = await CloudStorageProviderFactory.ValidateAsync(_preferences, providerId);
+        var connection = GetConnection(providerId);
+        connection.IsConnected = result.IsSuccess;
+        connection.LastError = result.IsSuccess ? null : result.Message;
+        connection.LastValidatedAt = DateTimeOffset.UtcNow;
+        _providerMessages[providerId] = result.Message;
+        await PersistPreferencesAsync();
+    }
+
+    private async Task ExportAsync(string providerId)
+    {
+        var result = await CloudStorageTransferService.ExportAsync(_preferences, providerId);
+        _providerMessages[providerId] = result.Message;
+    }
+
+    private async Task ImportAsync(string providerId)
+    {
+        var result = await CloudStorageTransferService.ImportAsync(_preferences, providerId);
+        _providerMessages[providerId] = result.Message;
+
+        if (result.IsSuccess)
+        {
+            await SettingsImported.InvokeAsync();
+        }
+    }
+
+    private async Task DisconnectAsync(string providerId)
+    {
+        await CloudStorageStore.RemoveCredentialsAsync(providerId);
+        ResetProvider(providerId);
+        _providerMessages[providerId] = "Provider disconnected.";
+        await PersistPreferencesAsync();
+    }
+
+    private Task PersistPreferencesAsync() => CloudStorageStore.SavePreferencesAsync(_preferences);
+
+    private async Task EnsureProviderCardOpenAsync(string providerId)
+    {
+        if (string.IsNullOrWhiteSpace(providerId) || IsCardOpen(providerId))
+        {
+            return;
+        }
+
+        await ToggleCard.InvokeAsync(providerId);
+    }
+
+    private async Task PersistProviderAsync(string providerId)
+    {
+        await PersistPreferencesAsync();
+
+        switch (providerId)
+        {
+            case CloudStorageProviderIds.Dropbox:
+                await CloudStorageStore.SaveDropboxCredentialsAsync(_dropboxCredentials);
+                break;
+            case CloudStorageProviderIds.OneDrive:
+                await CloudStorageStore.SaveOneDriveCredentialsAsync(_oneDriveCredentials);
+                break;
+            case CloudStorageProviderIds.GoogleDrive:
+                await CloudStorageStore.SaveGoogleDriveCredentialsAsync(_googleDriveCredentials);
+                break;
+            case CloudStorageProviderIds.GoogleCloudStorage:
+                await CloudStorageStore.SaveGoogleCloudStorageCredentialsAsync(_googleCloudStorageCredentials);
+                break;
+            case CloudStorageProviderIds.CloudKit:
+                await CloudStorageStore.SaveCloudKitCredentialsAsync(_cloudKitCredentials);
+                break;
+            default:
+                throw new InvalidOperationException($"Unknown cloud storage provider '{providerId}'.");
+        }
+    }
+
+    private void ResetProvider(string providerId)
+    {
+        switch (providerId)
+        {
+            case CloudStorageProviderIds.Dropbox:
+                _preferences.Dropbox = new DropboxCloudStorageProfile();
+                _dropboxCredentials = new DropboxCloudStorageCredentials();
+                break;
+            case CloudStorageProviderIds.OneDrive:
+                _preferences.OneDrive = new OneDriveCloudStorageProfile();
+                _oneDriveCredentials = new OneDriveCloudStorageCredentials();
+                break;
+            case CloudStorageProviderIds.GoogleDrive:
+                _preferences.GoogleDrive = new GoogleDriveCloudStorageProfile();
+                _googleDriveCredentials = new GoogleDriveCloudStorageCredentials();
+                break;
+            case CloudStorageProviderIds.GoogleCloudStorage:
+                _preferences.GoogleCloudStorage = new GoogleCloudStorageProfile();
+                _googleCloudStorageCredentials = new GoogleCloudStorageCredentials();
+                break;
+            case CloudStorageProviderIds.CloudKit:
+                _preferences.CloudKit = new CloudKitStorageProfile();
+                _cloudKitCredentials = new CloudKitStorageCredentials();
+                break;
+            default:
+                throw new InvalidOperationException($"Unknown cloud storage provider '{providerId}'.");
+        }
+    }
+
+    private CloudStorageConnectionState GetConnection(string providerId) => providerId switch
+    {
+        CloudStorageProviderIds.CloudKit => _preferences.CloudKit.Connection,
+        CloudStorageProviderIds.Dropbox => _preferences.Dropbox.Connection,
+        CloudStorageProviderIds.GoogleCloudStorage => _preferences.GoogleCloudStorage.Connection,
+        CloudStorageProviderIds.GoogleDrive => _preferences.GoogleDrive.Connection,
+        CloudStorageProviderIds.OneDrive => _preferences.OneDrive.Connection,
+        _ => throw new InvalidOperationException($"Unknown cloud storage provider '{providerId}'.")
+    };
+
+    private static string BuildToggleCssClass(bool isOn) =>
+        isOn ? $"{SetToggleCssClass} {OnCssClass}" : SetToggleCssClass;
+
+    private static string GetStatusClass(CloudStorageConnectionState connection) =>
+        connection.IsConnected ? ConnectedStatusClass : string.Empty;
+
+    private static string GetStatusLabel(CloudStorageConnectionState connection) =>
+        connection.IsConnected ? ConnectedStatusLabel : DisconnectedStatusLabel;
+
+    private static string GetSubtitle(CloudStorageConnectionState connection) =>
+        string.IsNullOrWhiteSpace(connection.AccountLabel) ? DisconnectedSubtitle : connection.AccountLabel;
+
+    private RenderFragment ProviderActions(string providerId) => builder =>
+    {
+        var isConnected = GetConnection(providerId).IsConnected;
+        var message = _providerMessages.GetValueOrDefault(providerId) ?? GetConnection(providerId).LastError;
+
+        builder.AddMarkupContent(0, $"<div class=\"set-path-field\" style=\"margin-top:12px\">");
+        BuildActionButton(builder, 1, "set-btn-golden", UiTestIds.Settings.CloudProviderConnect(providerId), "Save & Test", () => SaveAndValidateAsync(providerId));
+        BuildActionButton(builder, 2, "set-btn-outline set-btn-sm", UiTestIds.Settings.CloudProviderExport(providerId), "Export", () => ExportAsync(providerId), !isConnected);
+        BuildActionButton(builder, 3, "set-btn-outline set-btn-sm", UiTestIds.Settings.CloudProviderImport(providerId), "Import", () => ImportAsync(providerId), !isConnected);
+        BuildActionButton(builder, 4, "set-btn-outline set-btn-sm set-danger-action", UiTestIds.Settings.CloudProviderDisconnect(providerId), "Disconnect", () => DisconnectAsync(providerId), !isConnected);
+        builder.AddMarkupContent(5, "</div>");
+
+        if (!string.IsNullOrWhiteSpace(message))
+        {
+            builder.OpenElement(6, "p");
+            builder.AddAttribute(7, "class", "set-card-copy");
+            builder.AddAttribute(8, "data-testid", UiTestIds.Settings.CloudProviderMessage(providerId));
+            builder.AddContent(9, message);
+            builder.CloseElement();
+        }
+    };
+
+    private void BuildActionButton(RenderTreeBuilder builder, int sequence, string cssClass, string testId, string label, Func<Task> callback, bool disabled = false)
+    {
+        builder.OpenElement(sequence, "button");
+        builder.AddAttribute(sequence + 1, "type", "button");
+        builder.AddAttribute(sequence + 2, "class", cssClass);
+        builder.AddAttribute(sequence + 3, "data-testid", testId);
+        builder.AddAttribute(sequence + 4, "disabled", disabled);
+        builder.AddAttribute(sequence + 5, "onclick", EventCallback.Factory.Create(this, callback));
+        builder.AddContent(sequence + 6, label);
+        builder.CloseElement();
+    }
+}

--- a/src/PrompterLive.Shared/Settings/Pages/SettingsPage.Preferences.cs
+++ b/src/PrompterLive.Shared/Settings/Pages/SettingsPage.Preferences.cs
@@ -39,6 +39,12 @@ public partial class SettingsPage
         await ThemeService.ApplyAsync(_pagePreferences);
     }
 
+    private async Task ReloadPreferencesAsync()
+    {
+        await LoadPreferencesAsync();
+        await InvokeAsync(StateHasChanged);
+    }
+
     private Task PersistPreferencesAsync() =>
         Diagnostics.RunAsync(
             PersistPreferencesOperation,
@@ -71,24 +77,6 @@ public partial class SettingsPage
         }
 
         await InvokeAsync(StateHasChanged);
-    }
-
-    private async Task UpdateOneDriveSyncFolderAsync(string value)
-    {
-        _pagePreferences = _pagePreferences with { OneDriveSyncFolder = value };
-        await PersistPreferencesAsync();
-    }
-
-    private async Task ToggleCloudAutoSyncOnSaveAsync()
-    {
-        _pagePreferences = _pagePreferences with { CloudAutoSyncOnSave = !_pagePreferences.CloudAutoSyncOnSave };
-        await PersistPreferencesAsync();
-    }
-
-    private async Task ToggleCloudSyncOnStartupAsync()
-    {
-        _pagePreferences = _pagePreferences with { CloudSyncOnStartup = !_pagePreferences.CloudSyncOnStartup };
-        await PersistPreferencesAsync();
     }
 
     private async Task UpdateExportFormatAsync(string value)

--- a/src/PrompterLive.Shared/Settings/Pages/SettingsPage.razor
+++ b/src/PrompterLive.Shared/Settings/Pages/SettingsPage.razor
@@ -65,13 +65,9 @@
         <div class="set-main">
             <SettingsCloudSection DisplayStyle="@GetSectionDisplayStyle(SettingsSection.Cloud)"
                                   IsCardOpen="IsCardOpen"
-                                  OneDriveSyncFolder="@_pagePreferences.OneDriveSyncFolder"
-                                  OneDriveSyncFolderChanged="UpdateOneDriveSyncFolderAsync"
-                                  CloudAutoSyncOnSave="@_pagePreferences.CloudAutoSyncOnSave"
-                                  CloudSyncOnStartup="@_pagePreferences.CloudSyncOnStartup"
+                                  SettingsImported="ReloadPreferencesAsync"
                                   ToggleCard="TogglePreferenceCardAsync"
-                                  ToggleAutoSyncOnSave="ToggleCloudAutoSyncOnSaveAsync"
-                                  ToggleSyncOnStartup="ToggleCloudSyncOnStartupAsync" />
+                                  />
 
             <SettingsFilesSection DisplayStyle="@GetSectionDisplayStyle(SettingsSection.Files)"
                                   IsCardOpen="IsCardOpen"

--- a/src/PrompterLive.Shared/Settings/Services/BrowserSettingsStore.cs
+++ b/src/PrompterLive.Shared/Settings/Services/BrowserSettingsStore.cs
@@ -55,6 +55,23 @@ public sealed class BrowserSettingsStore(IJSRuntime jsRuntime, ILogger<BrowserSe
         }
     }
 
+    public async Task RemoveAsync(string key, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            _logger.LogDebug("Removing browser setting {Key}.", key);
+            await _jsRuntime.InvokeVoidAsync(
+                BrowserStorageMethodNames.RemoveStorageValue,
+                cancellationToken,
+                ResolveStorageKey(key));
+        }
+        catch (Exception exception)
+        {
+            _logger.LogError(exception, "Failed to remove browser setting {Key}.", key);
+            throw;
+        }
+    }
+
     private static string ResolveStorageKey(string key) =>
         string.Concat(BrowserStorageKeys.SettingsPrefix, key);
 }

--- a/src/PrompterLive.Shared/Storage/BrowserAppSettingsKeys.cs
+++ b/src/PrompterLive.Shared/Storage/BrowserAppSettingsKeys.cs
@@ -1,0 +1,8 @@
+namespace PrompterLive.Shared.Storage;
+
+public static class BrowserAppSettingsKeys
+{
+    public const string LearnSettings = "prompterlive.learn";
+    public const string ReaderSettings = "prompterlive.reader";
+    public const string SceneSettings = "prompterlive.scene";
+}

--- a/src/PrompterLive.Shared/Storage/Cloud/BrowserCloudStorageStore.cs
+++ b/src/PrompterLive.Shared/Storage/Cloud/BrowserCloudStorageStore.cs
@@ -1,0 +1,77 @@
+using PrompterLive.Shared.Services;
+
+namespace PrompterLive.Shared.Storage.Cloud;
+
+public sealed class BrowserCloudStorageStore(BrowserSettingsStore settingsStore)
+{
+    private readonly BrowserSettingsStore _settingsStore = settingsStore;
+
+    public async Task<CloudStoragePreferences> LoadPreferencesAsync(CancellationToken cancellationToken = default)
+    {
+        var preferences = await _settingsStore.LoadAsync<CloudStoragePreferences>(
+            CloudStorageStoreKeys.Preferences,
+            cancellationToken);
+
+        return (preferences ?? CloudStoragePreferences.CreateDefault()).Normalize();
+    }
+
+    public Task SavePreferencesAsync(CloudStoragePreferences preferences, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(preferences);
+        return _settingsStore.SaveAsync(CloudStorageStoreKeys.Preferences, preferences.Normalize(), cancellationToken);
+    }
+
+    public async Task<DropboxCloudStorageCredentials> LoadDropboxCredentialsAsync(CancellationToken cancellationToken = default) =>
+        await LoadAsync<DropboxCloudStorageCredentials>(CloudStorageStoreKeys.DropboxCredentials, cancellationToken) ?? new();
+
+    public Task SaveDropboxCredentialsAsync(DropboxCloudStorageCredentials credentials, CancellationToken cancellationToken = default) =>
+        SaveAsync(CloudStorageStoreKeys.DropboxCredentials, credentials, cancellationToken);
+
+    public async Task<OneDriveCloudStorageCredentials> LoadOneDriveCredentialsAsync(CancellationToken cancellationToken = default) =>
+        await LoadAsync<OneDriveCloudStorageCredentials>(CloudStorageStoreKeys.OneDriveCredentials, cancellationToken) ?? new();
+
+    public Task SaveOneDriveCredentialsAsync(OneDriveCloudStorageCredentials credentials, CancellationToken cancellationToken = default) =>
+        SaveAsync(CloudStorageStoreKeys.OneDriveCredentials, credentials, cancellationToken);
+
+    public async Task<GoogleDriveCloudStorageCredentials> LoadGoogleDriveCredentialsAsync(CancellationToken cancellationToken = default) =>
+        await LoadAsync<GoogleDriveCloudStorageCredentials>(CloudStorageStoreKeys.GoogleDriveCredentials, cancellationToken) ?? new();
+
+    public Task SaveGoogleDriveCredentialsAsync(GoogleDriveCloudStorageCredentials credentials, CancellationToken cancellationToken = default) =>
+        SaveAsync(CloudStorageStoreKeys.GoogleDriveCredentials, credentials, cancellationToken);
+
+    public async Task<GoogleCloudStorageCredentials> LoadGoogleCloudStorageCredentialsAsync(CancellationToken cancellationToken = default) =>
+        await LoadAsync<GoogleCloudStorageCredentials>(CloudStorageStoreKeys.GoogleCloudStorageCredentials, cancellationToken) ?? new();
+
+    public Task SaveGoogleCloudStorageCredentialsAsync(GoogleCloudStorageCredentials credentials, CancellationToken cancellationToken = default) =>
+        SaveAsync(CloudStorageStoreKeys.GoogleCloudStorageCredentials, credentials, cancellationToken);
+
+    public async Task<CloudKitStorageCredentials> LoadCloudKitCredentialsAsync(CancellationToken cancellationToken = default) =>
+        await LoadAsync<CloudKitStorageCredentials>(CloudStorageStoreKeys.CloudKitCredentials, cancellationToken) ?? new();
+
+    public Task SaveCloudKitCredentialsAsync(CloudKitStorageCredentials credentials, CancellationToken cancellationToken = default) =>
+        SaveAsync(CloudStorageStoreKeys.CloudKitCredentials, credentials, cancellationToken);
+
+    public Task RemoveCredentialsAsync(string providerId, CancellationToken cancellationToken = default)
+    {
+        var key = providerId switch
+        {
+            CloudStorageProviderIds.CloudKit => CloudStorageStoreKeys.CloudKitCredentials,
+            CloudStorageProviderIds.Dropbox => CloudStorageStoreKeys.DropboxCredentials,
+            CloudStorageProviderIds.GoogleCloudStorage => CloudStorageStoreKeys.GoogleCloudStorageCredentials,
+            CloudStorageProviderIds.GoogleDrive => CloudStorageStoreKeys.GoogleDriveCredentials,
+            CloudStorageProviderIds.OneDrive => CloudStorageStoreKeys.OneDriveCredentials,
+            _ => throw new InvalidOperationException($"Unknown cloud storage provider '{providerId}'.")
+        };
+
+        return _settingsStore.RemoveAsync(key, cancellationToken);
+    }
+
+    private Task<T?> LoadAsync<T>(string key, CancellationToken cancellationToken) =>
+        _settingsStore.LoadAsync<T>(key, cancellationToken);
+
+    private Task SaveAsync<T>(string key, T value, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        return _settingsStore.SaveAsync(key, value, cancellationToken);
+    }
+}

--- a/src/PrompterLive.Shared/Storage/Cloud/CloudStorageFieldIds.cs
+++ b/src/PrompterLive.Shared/Storage/Cloud/CloudStorageFieldIds.cs
@@ -1,0 +1,27 @@
+namespace PrompterLive.Shared.Storage.Cloud;
+
+public static class CloudStorageFieldIds
+{
+    public const string AccessToken = "access-token";
+    public const string AccountLabel = "account-label";
+    public const string ApiToken = "api-token";
+    public const string AppKey = "app-key";
+    public const string AppSecret = "app-secret";
+    public const string BucketName = "bucket-name";
+    public const string ClientId = "client-id";
+    public const string ClientSecret = "client-secret";
+    public const string ContainerId = "container-id";
+    public const string Database = "database";
+    public const string DriveId = "drive-id";
+    public const string Environment = "environment";
+    public const string ProjectId = "project-id";
+    public const string RefreshToken = "refresh-token";
+    public const string RootFolderId = "root-folder-id";
+    public const string RootPath = "root-path";
+    public const string ServerPrivateKeyPem = "server-private-key-pem";
+    public const string ServerToServerKeyId = "server-to-server-key-id";
+    public const string ServiceAccountJson = "service-account-json";
+    public const string SupportsAllDrives = "supports-all-drives";
+    public const string TenantId = "tenant-id";
+    public const string WebAuthToken = "web-auth-token";
+}

--- a/src/PrompterLive.Shared/Storage/Cloud/CloudStorageModels.cs
+++ b/src/PrompterLive.Shared/Storage/Cloud/CloudStorageModels.cs
@@ -1,0 +1,185 @@
+using ManagedCode.Storage.CloudKit.Options;
+using PrompterLive.Core.Models.Documents;
+using PrompterLive.Core.Models.Library;
+using PrompterLive.Core.Models.Media;
+using PrompterLive.Core.Models.Workspace;
+using PrompterLive.Shared.Settings.Models;
+
+namespace PrompterLive.Shared.Storage.Cloud;
+
+public sealed class CloudStorageConnectionState
+{
+    public string AccountLabel { get; set; } = string.Empty;
+
+    public bool IsConnected { get; set; }
+
+    public string? LastError { get; set; }
+
+    public DateTimeOffset? LastValidatedAt { get; set; }
+
+    public string RootPath { get; set; } = string.Empty;
+}
+
+public sealed class DropboxCloudStorageProfile
+{
+    public CloudStorageConnectionState Connection { get; set; } = new()
+    {
+        RootPath = "/apps/prompterlive"
+    };
+}
+
+public sealed class OneDriveCloudStorageProfile
+{
+    public CloudStorageConnectionState Connection { get; set; } = new()
+    {
+        RootPath = "PrompterLive"
+    };
+
+    public string DriveId { get; set; } = "me";
+}
+
+public sealed class GoogleDriveCloudStorageProfile
+{
+    public CloudStorageConnectionState Connection { get; set; } = new()
+    {
+        RootPath = "prompterlive"
+    };
+
+    public string RootFolderId { get; set; } = "root";
+
+    public bool SupportsAllDrives { get; set; } = true;
+}
+
+public sealed class GoogleCloudStorageProfile
+{
+    public string BucketName { get; set; } = string.Empty;
+
+    public CloudStorageConnectionState Connection { get; set; } = new()
+    {
+        RootPath = "prompterlive"
+    };
+
+    public string ProjectId { get; set; } = string.Empty;
+}
+
+public sealed class CloudKitStorageProfile
+{
+    public string ContainerId { get; set; } = string.Empty;
+
+    public CloudStorageConnectionState Connection { get; set; } = new()
+    {
+        RootPath = "prompterlive"
+    };
+
+    public CloudKitDatabase Database { get; set; } = CloudKitDatabase.Public;
+
+    public CloudKitEnvironment Environment { get; set; } = CloudKitEnvironment.Development;
+}
+
+public sealed class CloudStoragePreferences
+{
+    public bool AutoSyncOnSave { get; set; } = true;
+
+    public CloudKitStorageProfile CloudKit { get; set; } = new();
+
+    public DropboxCloudStorageProfile Dropbox { get; set; } = new();
+
+    public GoogleCloudStorageProfile GoogleCloudStorage { get; set; } = new();
+
+    public GoogleDriveCloudStorageProfile GoogleDrive { get; set; } = new();
+
+    public OneDriveCloudStorageProfile OneDrive { get; set; } = new();
+
+    public string PrimaryProviderId { get; set; } = CloudStorageProviderIds.OneDrive;
+
+    public bool SyncOnStartup { get; set; } = true;
+
+    public static CloudStoragePreferences CreateDefault() => new();
+
+    public CloudStoragePreferences Normalize()
+    {
+        CloudKit ??= new CloudKitStorageProfile();
+        Dropbox ??= new DropboxCloudStorageProfile();
+        GoogleCloudStorage ??= new GoogleCloudStorageProfile();
+        GoogleDrive ??= new GoogleDriveCloudStorageProfile();
+        OneDrive ??= new OneDriveCloudStorageProfile();
+        PrimaryProviderId = string.IsNullOrWhiteSpace(PrimaryProviderId) ? CloudStorageProviderIds.OneDrive : PrimaryProviderId;
+        return this;
+    }
+}
+
+public sealed class DropboxCloudStorageCredentials
+{
+    public string AccessToken { get; set; } = string.Empty;
+
+    public string AppKey { get; set; } = string.Empty;
+
+    public string AppSecret { get; set; } = string.Empty;
+
+    public string RefreshToken { get; set; } = string.Empty;
+}
+
+public sealed class OneDriveCloudStorageCredentials
+{
+    public string ClientId { get; set; } = string.Empty;
+
+    public string ClientSecret { get; set; } = string.Empty;
+
+    public string TenantId { get; set; } = string.Empty;
+}
+
+public sealed class GoogleDriveCloudStorageCredentials
+{
+    public string ServiceAccountJson { get; set; } = string.Empty;
+}
+
+public sealed class GoogleCloudStorageCredentials
+{
+    public string ServiceAccountJson { get; set; } = string.Empty;
+}
+
+public sealed class CloudKitStorageCredentials
+{
+    public string ApiToken { get; set; } = string.Empty;
+
+    public string ServerToServerKeyId { get; set; } = string.Empty;
+
+    public string ServerToServerPrivateKeyPem { get; set; } = string.Empty;
+
+    public string WebAuthToken { get; set; } = string.Empty;
+}
+
+public sealed class CloudStorageSettingsBundle
+{
+    public LearnSettings LearnSettings { get; set; } = new();
+
+    public ReaderSettings ReaderSettings { get; set; } = new();
+
+    public MediaSceneState SceneState { get; set; } = MediaSceneState.Empty;
+
+    public SettingsPagePreferences SettingsPagePreferences { get; set; } = SettingsPagePreferences.Default;
+
+    public StudioSettings StudioSettings { get; set; } = StudioSettings.Default;
+}
+
+public sealed class CloudStorageBackupEnvelope
+{
+    public const string CurrentSchemaVersion = "1";
+
+    public DateTimeOffset ExportedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    public IReadOnlyList<StoredLibraryFolder> Folders { get; set; } = Array.Empty<StoredLibraryFolder>();
+
+    public string SchemaVersion { get; set; } = CurrentSchemaVersion;
+
+    public IReadOnlyList<StoredScriptDocument> Scripts { get; set; } = Array.Empty<StoredScriptDocument>();
+
+    public CloudStorageSettingsBundle Settings { get; set; } = new();
+}
+
+public sealed record CloudStorageOperationResult(bool IsSuccess, string Message)
+{
+    public static CloudStorageOperationResult Failure(string message) => new(false, message);
+
+    public static CloudStorageOperationResult Success(string message) => new(true, message);
+}

--- a/src/PrompterLive.Shared/Storage/Cloud/CloudStorageProviderFactory.cs
+++ b/src/PrompterLive.Shared/Storage/Cloud/CloudStorageProviderFactory.cs
@@ -1,0 +1,253 @@
+using Azure.Identity;
+using Google.Apis.Auth.OAuth2;
+using Google.Apis.Drive.v3;
+using Google.Apis.Services;
+using ManagedCode.Storage.CloudKit;
+using ManagedCode.Storage.CloudKit.Options;
+using ManagedCode.Storage.Core;
+using ManagedCode.Storage.Dropbox;
+using ManagedCode.Storage.Dropbox.Options;
+using ManagedCode.Storage.Google;
+using ManagedCode.Storage.Google.Options;
+using ManagedCode.Storage.GoogleDrive;
+using ManagedCode.Storage.GoogleDrive.Options;
+using ManagedCode.Storage.OneDrive;
+using ManagedCode.Storage.OneDrive.Options;
+using Microsoft.Extensions.Logging;
+using Microsoft.Graph;
+
+namespace PrompterLive.Shared.Storage.Cloud;
+
+public sealed class CloudStorageProviderFactory(
+    BrowserCloudStorageStore cloudStorageStore,
+    ILoggerFactory loggerFactory)
+{
+    private const string GoogleCloudStorageScope = "https://www.googleapis.com/auth/devstorage.full_control";
+    private const string GoogleDriveApplicationName = "PrompterLive";
+    private static readonly string[] GraphScopes = ["https://graph.microsoft.com/.default"];
+
+    private readonly BrowserCloudStorageStore _cloudStorageStore = cloudStorageStore;
+    private readonly ILoggerFactory _loggerFactory = loggerFactory;
+
+    public async Task<IStorage> CreateAsync(
+        CloudStoragePreferences preferences,
+        string providerId,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(preferences);
+
+        return providerId switch
+        {
+            CloudStorageProviderIds.CloudKit => await CreateCloudKitStorageAsync(preferences.CloudKit, cancellationToken),
+            CloudStorageProviderIds.Dropbox => await CreateDropboxStorageAsync(preferences.Dropbox, cancellationToken),
+            CloudStorageProviderIds.GoogleCloudStorage => await CreateGoogleCloudStorageAsync(preferences.GoogleCloudStorage, cancellationToken),
+            CloudStorageProviderIds.GoogleDrive => await CreateGoogleDriveStorageAsync(preferences.GoogleDrive, cancellationToken),
+            CloudStorageProviderIds.OneDrive => await CreateOneDriveStorageAsync(preferences.OneDrive, cancellationToken),
+            _ => throw new InvalidOperationException($"Unknown cloud storage provider '{providerId}'.")
+        };
+    }
+
+    public async Task<CloudStorageOperationResult> ValidateAsync(
+        CloudStoragePreferences preferences,
+        string providerId,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var storage = await CreateAsync(preferences, providerId, cancellationToken);
+            var result = await storage.CreateContainerAsync(cancellationToken);
+            return result.IsSuccess
+                ? CloudStorageOperationResult.Success("Connection validated.")
+                : CloudStorageOperationResult.Failure(ToMessage(result.Problem, "Connection failed."));
+        }
+        catch (Exception exception)
+        {
+            return CloudStorageOperationResult.Failure(exception.Message);
+        }
+    }
+
+    private async Task<IStorage> CreateDropboxStorageAsync(
+        DropboxCloudStorageProfile profile,
+        CancellationToken cancellationToken)
+    {
+        var credentials = await _cloudStorageStore.LoadDropboxCredentialsAsync(cancellationToken);
+        ValidateDropboxCredentials(credentials);
+
+        return new DropboxStorage(
+            new DropboxStorageOptions
+            {
+                AccessToken = credentials.AccessToken,
+                AppKey = credentials.AppKey,
+                AppSecret = credentials.AppSecret,
+                RefreshToken = credentials.RefreshToken,
+                RootPath = profile.Connection.RootPath
+            },
+            _loggerFactory.CreateLogger<DropboxStorage>());
+    }
+
+    private async Task<IStorage> CreateOneDriveStorageAsync(
+        OneDriveCloudStorageProfile profile,
+        CancellationToken cancellationToken)
+    {
+        var credentials = await _cloudStorageStore.LoadOneDriveCredentialsAsync(cancellationToken);
+        ValidateOneDriveCredentials(credentials);
+
+        var graphClient = new GraphServiceClient(
+            new ClientSecretCredential(credentials.TenantId, credentials.ClientId, credentials.ClientSecret),
+            GraphScopes);
+
+        return new OneDriveStorage(
+            new OneDriveStorageOptions
+            {
+                DriveId = profile.DriveId,
+                GraphClient = graphClient,
+                RootPath = profile.Connection.RootPath
+            },
+            _loggerFactory.CreateLogger<OneDriveStorage>());
+    }
+
+    private async Task<IStorage> CreateGoogleDriveStorageAsync(
+        GoogleDriveCloudStorageProfile profile,
+        CancellationToken cancellationToken)
+    {
+        var credentials = await _cloudStorageStore.LoadGoogleDriveCredentialsAsync(cancellationToken);
+        ValidateServiceAccountJson(credentials.ServiceAccountJson, "Google Drive");
+
+        var driveCredential = CredentialFactory
+            .FromJson<ServiceAccountCredential>(credentials.ServiceAccountJson)
+            .ToGoogleCredential()
+            .CreateScoped(DriveService.Scope.Drive);
+
+        var driveService = new DriveService(new BaseClientService.Initializer
+        {
+            ApplicationName = GoogleDriveApplicationName,
+            HttpClientInitializer = driveCredential
+        });
+
+        return new GoogleDriveStorage(
+            new GoogleDriveStorageOptions
+            {
+                CreateContainerIfNotExists = true,
+                DriveService = driveService,
+                RootFolderId = profile.RootFolderId,
+                SupportsAllDrives = profile.SupportsAllDrives
+            },
+            _loggerFactory.CreateLogger<GoogleDriveStorage>());
+    }
+
+    private async Task<IStorage> CreateGoogleCloudStorageAsync(
+        GoogleCloudStorageProfile profile,
+        CancellationToken cancellationToken)
+    {
+        var credentials = await _cloudStorageStore.LoadGoogleCloudStorageCredentialsAsync(cancellationToken);
+        ValidateGoogleCloudStorage(profile, credentials);
+
+        var googleCredential = CredentialFactory
+            .FromJson<ServiceAccountCredential>(credentials.ServiceAccountJson)
+            .ToGoogleCredential()
+            .CreateScoped(GoogleCloudStorageScope);
+
+        return new GCPStorage(
+            new GCPStorageOptions
+            {
+                BucketOptions = new BucketOptions
+                {
+                    Bucket = profile.BucketName,
+                    ProjectId = profile.ProjectId
+                },
+                CreateContainerIfNotExists = true,
+                GoogleCredential = googleCredential
+            },
+            _loggerFactory.CreateLogger<GCPStorage>());
+    }
+
+    private async Task<IStorage> CreateCloudKitStorageAsync(
+        CloudKitStorageProfile profile,
+        CancellationToken cancellationToken)
+    {
+        var credentials = await _cloudStorageStore.LoadCloudKitCredentialsAsync(cancellationToken);
+        ValidateCloudKit(profile, credentials);
+
+        return new CloudKitStorage(
+            new CloudKitStorageOptions
+            {
+                ApiToken = NullIfWhiteSpace(credentials.ApiToken),
+                ContainerId = profile.ContainerId,
+                Database = profile.Database,
+                Environment = profile.Environment,
+                RootPath = profile.Connection.RootPath,
+                ServerToServerKeyId = NullIfWhiteSpace(credentials.ServerToServerKeyId),
+                ServerToServerPrivateKeyPem = NullIfWhiteSpace(credentials.ServerToServerPrivateKeyPem),
+                WebAuthToken = NullIfWhiteSpace(credentials.WebAuthToken)
+            },
+            _loggerFactory.CreateLogger<CloudKitStorage>());
+    }
+
+    private static void ValidateDropboxCredentials(DropboxCloudStorageCredentials credentials)
+    {
+        var hasAccessToken = !string.IsNullOrWhiteSpace(credentials.AccessToken);
+        var hasRefreshFlow = !string.IsNullOrWhiteSpace(credentials.RefreshToken) &&
+            !string.IsNullOrWhiteSpace(credentials.AppKey);
+
+        if (!hasAccessToken && !hasRefreshFlow)
+        {
+            throw new InvalidOperationException("Dropbox requires an access token or a refresh token with app key.");
+        }
+    }
+
+    private static void ValidateOneDriveCredentials(OneDriveCloudStorageCredentials credentials)
+    {
+        if (string.IsNullOrWhiteSpace(credentials.TenantId) ||
+            string.IsNullOrWhiteSpace(credentials.ClientId) ||
+            string.IsNullOrWhiteSpace(credentials.ClientSecret))
+        {
+            throw new InvalidOperationException("OneDrive requires tenant id, client id, and client secret.");
+        }
+    }
+
+    private static void ValidateServiceAccountJson(string value, string providerName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new InvalidOperationException($"{providerName} requires a service account JSON key.");
+        }
+    }
+
+    private static void ValidateGoogleCloudStorage(
+        GoogleCloudStorageProfile profile,
+        GoogleCloudStorageCredentials credentials)
+    {
+        ValidateServiceAccountJson(credentials.ServiceAccountJson, "Google Cloud Storage");
+
+        if (string.IsNullOrWhiteSpace(profile.ProjectId) || string.IsNullOrWhiteSpace(profile.BucketName))
+        {
+            throw new InvalidOperationException("Google Cloud Storage requires a project id and bucket name.");
+        }
+    }
+
+    private static void ValidateCloudKit(
+        CloudKitStorageProfile profile,
+        CloudKitStorageCredentials credentials)
+    {
+        if (string.IsNullOrWhiteSpace(profile.ContainerId))
+        {
+            throw new InvalidOperationException("CloudKit requires a container id.");
+        }
+
+        var hasApiToken = !string.IsNullOrWhiteSpace(credentials.ApiToken);
+        var hasServerCredentials = !string.IsNullOrWhiteSpace(credentials.ServerToServerKeyId) &&
+            !string.IsNullOrWhiteSpace(credentials.ServerToServerPrivateKeyPem);
+        var hasWebToken = !string.IsNullOrWhiteSpace(credentials.WebAuthToken);
+
+        if (!hasApiToken && !hasServerCredentials && !hasWebToken)
+        {
+            throw new InvalidOperationException("CloudKit requires an API token, web auth token, or server-to-server credentials.");
+        }
+    }
+
+    private static string? NullIfWhiteSpace(string value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value;
+
+    private static string ToMessage(ManagedCode.Communication.Problem? problem, string fallbackMessage) =>
+        problem?.Detail ?? problem?.Title ?? fallbackMessage;
+}

--- a/src/PrompterLive.Shared/Storage/Cloud/CloudStorageProviderIds.cs
+++ b/src/PrompterLive.Shared/Storage/Cloud/CloudStorageProviderIds.cs
@@ -1,0 +1,10 @@
+namespace PrompterLive.Shared.Storage.Cloud;
+
+public static class CloudStorageProviderIds
+{
+    public const string CloudKit = "cloudkit";
+    public const string Dropbox = "dropbox";
+    public const string GoogleCloudStorage = "google-cloud-storage";
+    public const string GoogleDrive = "google-drive";
+    public const string OneDrive = "onedrive";
+}

--- a/src/PrompterLive.Shared/Storage/Cloud/CloudStorageStoreKeys.cs
+++ b/src/PrompterLive.Shared/Storage/Cloud/CloudStorageStoreKeys.cs
@@ -1,0 +1,15 @@
+namespace PrompterLive.Shared.Storage.Cloud;
+
+public static class CloudStorageStoreKeys
+{
+    public const string BackupDirectory = "prompterlive";
+    public const string BackupFileName = "scripts-settings.json";
+    public const string BackupPath = BackupDirectory + "/" + BackupFileName;
+    public const string CloudKitCredentials = "prompterlive.cloud-storage.credentials.cloudkit";
+    public const string DropboxCredentials = "prompterlive.cloud-storage.credentials.dropbox";
+    public const string GoogleCloudStorageCredentials = "prompterlive.cloud-storage.credentials.google-cloud-storage";
+    public const string GoogleDriveCredentials = "prompterlive.cloud-storage.credentials.google-drive";
+    public const string JsonMimeType = "application/json";
+    public const string OneDriveCredentials = "prompterlive.cloud-storage.credentials.onedrive";
+    public const string Preferences = "prompterlive.cloud-storage.preferences";
+}

--- a/src/PrompterLive.Shared/Storage/Cloud/CloudStorageTransferService.cs
+++ b/src/PrompterLive.Shared/Storage/Cloud/CloudStorageTransferService.cs
@@ -1,0 +1,261 @@
+using System.Text.Json;
+using ManagedCode.Communication;
+using ManagedCode.Storage.Core.Models;
+using PrompterLive.Core.Abstractions;
+using PrompterLive.Core.Models.Documents;
+using PrompterLive.Core.Models.Library;
+using PrompterLive.Core.Models.Media;
+using PrompterLive.Core.Models.Workspace;
+using PrompterLive.Shared.Services;
+using PrompterLive.Shared.Settings.Models;
+
+namespace PrompterLive.Shared.Storage.Cloud;
+
+public sealed class CloudStorageTransferService(
+    BrowserSettingsStore settingsStore,
+    BrowserThemeService themeService,
+    CloudStorageProviderFactory providerFactory,
+    ILibraryFolderRepository libraryFolderRepository,
+    IScriptRepository scriptRepository,
+    IScriptSessionService scriptSessionService,
+    IMediaSceneService mediaSceneService,
+    StudioSettingsStore studioSettingsStore)
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        WriteIndented = true
+    };
+
+    private readonly ILibraryFolderRepository _libraryFolderRepository = libraryFolderRepository;
+    private readonly IMediaSceneService _mediaSceneService = mediaSceneService;
+    private readonly CloudStorageProviderFactory _providerFactory = providerFactory;
+    private readonly IScriptRepository _scriptRepository = scriptRepository;
+    private readonly IScriptSessionService _scriptSessionService = scriptSessionService;
+    private readonly BrowserSettingsStore _settingsStore = settingsStore;
+    private readonly StudioSettingsStore _studioSettingsStore = studioSettingsStore;
+    private readonly BrowserThemeService _themeService = themeService;
+
+    public async Task<CloudStorageOperationResult> ExportAsync(
+        CloudStoragePreferences preferences,
+        string providerId,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var storage = await _providerFactory.CreateAsync(preferences, providerId, cancellationToken);
+            var createResult = await storage.CreateContainerAsync(cancellationToken);
+            if (!createResult.IsSuccess)
+            {
+                return CloudStorageOperationResult.Failure(ToMessage(createResult.Problem, "Unable to initialize the selected provider."));
+            }
+
+            var backup = await BuildBackupAsync(cancellationToken);
+            var payload = JsonSerializer.Serialize(backup, JsonOptions);
+            var uploadResult = await storage.UploadAsync(
+                payload,
+                CreateUploadOptions,
+                cancellationToken);
+
+            return uploadResult.IsSuccess
+                ? CloudStorageOperationResult.Success($"Exported {backup.Scripts.Count} scripts and settings.")
+                : CloudStorageOperationResult.Failure(ToMessage(uploadResult.Problem, "Unable to upload the backup snapshot."));
+        }
+        catch (Exception exception)
+        {
+            return CloudStorageOperationResult.Failure(exception.Message);
+        }
+    }
+
+    public async Task<CloudStorageOperationResult> ImportAsync(
+        CloudStoragePreferences preferences,
+        string providerId,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var storage = await _providerFactory.CreateAsync(preferences, providerId, cancellationToken);
+            var createResult = await storage.CreateContainerAsync(cancellationToken);
+            if (!createResult.IsSuccess)
+            {
+                return CloudStorageOperationResult.Failure(ToMessage(createResult.Problem, "Unable to initialize the selected provider."));
+            }
+
+            var streamResult = await storage.GetStreamAsync(CloudStorageStoreKeys.BackupPath, cancellationToken);
+            if (!streamResult.IsSuccess || streamResult.Value is null)
+            {
+                return CloudStorageOperationResult.Failure(ToMessage(streamResult.Problem, "No backup snapshot was found for this provider."));
+            }
+
+            using var stream = streamResult.Value;
+            using var reader = new StreamReader(stream);
+            var payload = await reader.ReadToEndAsync(cancellationToken);
+            var backup = JsonSerializer.Deserialize<CloudStorageBackupEnvelope>(payload, JsonOptions);
+
+            if (backup is null)
+            {
+                return CloudStorageOperationResult.Failure("The backup snapshot is empty or invalid.");
+            }
+
+            await RestoreBackupAsync(backup, cancellationToken);
+            return CloudStorageOperationResult.Success($"Imported {backup.Scripts.Count} scripts and settings.");
+        }
+        catch (Exception exception)
+        {
+            return CloudStorageOperationResult.Failure(exception.Message);
+        }
+    }
+
+    private async Task<CloudStorageBackupEnvelope> BuildBackupAsync(CancellationToken cancellationToken)
+    {
+        var documents = await LoadScriptsAsync(cancellationToken);
+        var folders = await _libraryFolderRepository.ListAsync(cancellationToken);
+        var settingsBundle = await BuildSettingsBundleAsync(cancellationToken);
+
+        return new CloudStorageBackupEnvelope
+        {
+            ExportedAt = DateTimeOffset.UtcNow,
+            Folders = folders,
+            Scripts = documents,
+            Settings = settingsBundle
+        };
+    }
+
+    private async Task<IReadOnlyList<StoredScriptDocument>> LoadScriptsAsync(CancellationToken cancellationToken)
+    {
+        var summaries = await _scriptRepository.ListAsync(cancellationToken);
+        var documents = new List<StoredScriptDocument>(summaries.Count);
+
+        foreach (var summary in summaries)
+        {
+            var document = await _scriptRepository.GetAsync(summary.Id, cancellationToken);
+            if (document is not null)
+            {
+                documents.Add(document);
+            }
+        }
+
+        return documents;
+    }
+
+    private async Task<CloudStorageSettingsBundle> BuildSettingsBundleAsync(CancellationToken cancellationToken)
+    {
+        return new CloudStorageSettingsBundle
+        {
+            LearnSettings = await _settingsStore.LoadAsync<LearnSettings>(BrowserAppSettingsKeys.LearnSettings, cancellationToken) ?? new LearnSettings(),
+            ReaderSettings = await _settingsStore.LoadAsync<ReaderSettings>(BrowserAppSettingsKeys.ReaderSettings, cancellationToken) ?? new ReaderSettings(),
+            SceneState = await _settingsStore.LoadAsync<MediaSceneState>(BrowserAppSettingsKeys.SceneSettings, cancellationToken) ?? MediaSceneState.Empty,
+            SettingsPagePreferences = await _settingsStore.LoadAsync<SettingsPagePreferences>(SettingsPagePreferences.StorageKey, cancellationToken) ?? SettingsPagePreferences.Default,
+            StudioSettings = await _studioSettingsStore.LoadAsync(cancellationToken)
+        };
+    }
+
+    private async Task RestoreBackupAsync(CloudStorageBackupEnvelope backup, CancellationToken cancellationToken)
+    {
+        var folderMap = await RestoreFoldersAsync(backup.Folders, cancellationToken);
+        await RestoreScriptsAsync(backup.Scripts, folderMap, cancellationToken);
+        await RestoreSettingsAsync(backup.Settings, cancellationToken);
+    }
+
+    private async Task<Dictionary<string, string>> RestoreFoldersAsync(
+        IReadOnlyList<StoredLibraryFolder> importedFolders,
+        CancellationToken cancellationToken)
+    {
+        var existingFolders = (await _libraryFolderRepository.ListAsync(cancellationToken)).ToList();
+        var importedToLocal = new Dictionary<string, string>(StringComparer.Ordinal);
+        var pending = importedFolders.OrderBy(folder => folder.DisplayOrder).ToList();
+
+        while (pending.Count > 0)
+        {
+            var processedInPass = 0;
+
+            for (var index = pending.Count - 1; index >= 0; index--)
+            {
+                var importedFolder = pending[index];
+                var parentLocalId = ResolveParentLocalId(importedFolder.ParentId, importedToLocal);
+                if (importedFolder.ParentId is not null && parentLocalId is null)
+                {
+                    continue;
+                }
+
+                var existingFolder = existingFolders.FirstOrDefault(folder =>
+                    string.Equals(folder.Name, importedFolder.Name, StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(folder.ParentId, parentLocalId, StringComparison.Ordinal));
+
+                if (existingFolder is null)
+                {
+                    existingFolder = await _libraryFolderRepository.CreateAsync(
+                        importedFolder.Name,
+                        parentLocalId,
+                        cancellationToken);
+
+                    existingFolders.Add(existingFolder);
+                }
+
+                importedToLocal[importedFolder.Id] = existingFolder.Id;
+                pending.RemoveAt(index);
+                processedInPass++;
+            }
+
+            if (processedInPass == 0)
+            {
+                break;
+            }
+        }
+
+        return importedToLocal;
+    }
+
+    private async Task RestoreScriptsAsync(
+        IReadOnlyList<StoredScriptDocument> importedScripts,
+        IReadOnlyDictionary<string, string> folderMap,
+        CancellationToken cancellationToken)
+    {
+        foreach (var importedScript in importedScripts)
+        {
+            var folderId = ResolveParentLocalId(importedScript.FolderId, folderMap);
+            _ = await _scriptRepository.SaveAsync(
+                importedScript.Title,
+                importedScript.Text,
+                importedScript.DocumentName,
+                importedScript.Id,
+                folderId,
+                cancellationToken);
+        }
+    }
+
+    private async Task RestoreSettingsAsync(
+        CloudStorageSettingsBundle settings,
+        CancellationToken cancellationToken)
+    {
+        var bundle = settings ?? new CloudStorageSettingsBundle();
+
+        await _settingsStore.SaveAsync(SettingsPagePreferences.StorageKey, bundle.SettingsPagePreferences, cancellationToken);
+        await _settingsStore.SaveAsync(BrowserAppSettingsKeys.ReaderSettings, bundle.ReaderSettings, cancellationToken);
+        await _settingsStore.SaveAsync(BrowserAppSettingsKeys.LearnSettings, bundle.LearnSettings, cancellationToken);
+        await _settingsStore.SaveAsync(BrowserAppSettingsKeys.SceneSettings, bundle.SceneState, cancellationToken);
+        await _studioSettingsStore.SaveAsync(bundle.StudioSettings, cancellationToken);
+
+        await _scriptSessionService.UpdateReaderSettingsAsync(bundle.ReaderSettings);
+        await _scriptSessionService.UpdateLearnSettingsAsync(bundle.LearnSettings);
+        _mediaSceneService.ApplyState(bundle.SceneState);
+        await _themeService.ApplyAsync(bundle.SettingsPagePreferences, cancellationToken);
+    }
+
+    private static string? ResolveParentLocalId(
+        string? importedParentId,
+        IReadOnlyDictionary<string, string> folderMap) =>
+        !string.IsNullOrWhiteSpace(importedParentId) && folderMap.TryGetValue(importedParentId, out var localId)
+            ? localId
+            : null;
+
+    private static void CreateUploadOptions(UploadOptions options)
+    {
+        options.Directory = CloudStorageStoreKeys.BackupDirectory;
+        options.FileName = CloudStorageStoreKeys.BackupFileName;
+        options.MimeType = CloudStorageStoreKeys.JsonMimeType;
+    }
+
+    private static string ToMessage(Problem? problem, string fallbackMessage) =>
+        problem?.Detail ?? problem?.Title ?? fallbackMessage;
+}

--- a/src/PrompterLive.Shared/Storage/PrompterStorageDefaults.cs
+++ b/src/PrompterLive.Shared/Storage/PrompterStorageDefaults.cs
@@ -1,0 +1,15 @@
+namespace PrompterLive.Shared.Storage;
+
+public static class PrompterStorageDefaults
+{
+    public const int BrowserChunkBatchSize = 4;
+    public const int BrowserChunkSizeBytes = 4 * 1024 * 1024;
+    public const string LocalBrowserContainerName = "prompterlive-local";
+    public const string LocalBrowserDatabaseName = "prompterlive-storage";
+
+    public const string LibraryRootPath = "/library";
+    public const string ScriptDirectoryPath = LibraryRootPath + "/scripts";
+    public const string FolderDirectoryPath = LibraryRootPath + "/folders";
+    public const string SettingsRootPath = "/settings";
+    public const string SettingsSnapshotFilePath = SettingsRootPath + "/browser-settings.json";
+}

--- a/src/PrompterLive.Shared/Storage/VfsDirectoryProvisioner.cs
+++ b/src/PrompterLive.Shared/Storage/VfsDirectoryProvisioner.cs
@@ -1,0 +1,31 @@
+using ManagedCode.Storage.VirtualFileSystem.Core;
+
+namespace PrompterLive.Shared.Storage;
+
+internal static class VfsDirectoryProvisioner
+{
+    public static async Task EnsureDirectoryAsync(
+        IVirtualFileSystem fileSystem,
+        VfsPath path,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(fileSystem);
+
+        if (path.IsRoot)
+        {
+            return;
+        }
+
+        var directory = await fileSystem.GetDirectoryAsync(path, cancellationToken);
+        if (await directory.ExistsAsync(cancellationToken))
+        {
+            return;
+        }
+
+        var parent = path.GetParent();
+        await EnsureDirectoryAsync(fileSystem, parent, cancellationToken);
+
+        var parentDirectory = await fileSystem.GetDirectoryAsync(parent, cancellationToken);
+        _ = await parentDirectory.CreateDirectoryAsync(path.GetFileName(), cancellationToken);
+    }
+}

--- a/tests/PrompterLive.App.Tests/Library/LegacyLibrarySeedCatalogTests.cs
+++ b/tests/PrompterLive.App.Tests/Library/LegacyLibrarySeedCatalogTests.cs
@@ -1,0 +1,32 @@
+using PrompterLive.Shared.Services;
+
+namespace PrompterLive.App.Tests;
+
+public sealed class LegacyLibrarySeedCatalogTests
+{
+    [Fact]
+    public void IsLegacyDocument_DoesNotTreatTestScopedSeedFilesAsRuntimeLegacyContent()
+    {
+        var document = new BrowserStoredScriptDocumentDto
+        {
+            Id = "test-security-incident-script",
+            DocumentName = "test-security-incident.tps",
+            Title = "Security Incident"
+        };
+
+        Assert.False(LegacyLibrarySeedCatalog.IsLegacyDocument(document));
+    }
+
+    [Fact]
+    public void IsLegacyDocument_TreatsRemovedRuntimeSeedIdsAsLegacyContent()
+    {
+        var document = new BrowserStoredScriptDocumentDto
+        {
+            Id = "security-incident",
+            DocumentName = "security-incident.tps",
+            Title = "Security Incident"
+        };
+
+        Assert.True(LegacyLibrarySeedCatalog.IsLegacyDocument(document));
+    }
+}

--- a/tests/PrompterLive.App.Tests/Settings/SettingsInteractionTests.cs
+++ b/tests/PrompterLive.App.Tests/Settings/SettingsInteractionTests.cs
@@ -5,6 +5,7 @@ using PrompterLive.Shared.Contracts;
 using PrompterLive.Shared.Pages;
 using PrompterLive.Shared.Services;
 using PrompterLive.Shared.Settings.Models;
+using PrompterLive.Shared.Storage.Cloud;
 using PrompterLive.Shared.Tests;
 
 namespace PrompterLive.App.Tests;
@@ -16,6 +17,9 @@ public sealed class SettingsInteractionTests : BunitContext
     private const string FakeInfrastructureName = "Dmytro Shevchenko";
     private const string ReaderSettingsKey = "prompterlive.reader";
     private const string SceneSettingsKey = "prompterlive.scene";
+    private const string DropboxLabel = "Managed Dropbox";
+    private const string DropboxValidationMessage = "Dropbox requires an access token or a refresh token with app key.";
+    private const string NotConnectedLabel = "Not connected";
 
     private readonly AppHarness _harness;
 
@@ -38,6 +42,87 @@ public sealed class SettingsInteractionTests : BunitContext
         Assert.Equal(!initialValue, _harness.Session.State.ReaderSettings.ShowCameraScene);
         var readerSettings = _harness.JsRuntime.GetSavedValue<ReaderSettings>(ReaderSettingsKey);
         Assert.Equal(!initialValue, readerSettings.ShowCameraScene);
+    }
+
+    [Fact]
+    public void CloudSection_SaveAndTest_PersistsDropboxPreferences_AndShowsValidationMessage()
+    {
+        var cut = Render<SettingsPage>();
+
+        cut.WaitForAssertion(() => Assert.Contains(UiTestIds.Settings.CloudPanel, cut.Markup, StringComparison.Ordinal));
+
+        cut.FindByTestId(UiTestIds.Settings.CloudProviderField(CloudStorageProviderIds.Dropbox, CloudStorageFieldIds.AccountLabel))
+            .Change(DropboxLabel);
+        cut.FindByTestId(UiTestIds.Settings.CloudDefaultProvider).Change(CloudStorageProviderIds.Dropbox);
+        cut.FindByTestId(UiTestIds.Settings.CloudAutoSyncOnSave).Click();
+        cut.FindByTestId(UiTestIds.Settings.CloudProviderConnect(CloudStorageProviderIds.Dropbox)).Click();
+
+        var preferences = _harness.JsRuntime.GetSavedValue<CloudStoragePreferences>(CloudStorageStoreKeys.Preferences);
+        var credentials = _harness.JsRuntime.GetSavedValue<DropboxCloudStorageCredentials>(CloudStorageStoreKeys.DropboxCredentials);
+
+        Assert.Equal(CloudStorageProviderIds.Dropbox, preferences.PrimaryProviderId);
+        Assert.False(preferences.AutoSyncOnSave);
+        Assert.Equal(DropboxLabel, preferences.Dropbox.Connection.AccountLabel);
+        Assert.False(preferences.Dropbox.Connection.IsConnected);
+        Assert.Equal(string.Empty, credentials.AccessToken);
+        Assert.Equal(
+            DropboxValidationMessage,
+            cut.FindByTestId(UiTestIds.Settings.CloudProviderMessage(CloudStorageProviderIds.Dropbox)).TextContent.Trim());
+    }
+
+    [Fact]
+    public void CloudSection_Disconnect_ClearsStoredCredentials_AndResetsSubtitle()
+    {
+        var preferences = CloudStoragePreferences.CreateDefault();
+        preferences.PrimaryProviderId = CloudStorageProviderIds.Dropbox;
+        preferences.Dropbox = new DropboxCloudStorageProfile
+        {
+            Connection = new CloudStorageConnectionState
+            {
+                AccountLabel = DropboxLabel,
+                IsConnected = true,
+                RootPath = "/apps/prompterlive"
+            }
+        };
+        _harness.JsRuntime.SavedValues[CloudStorageStoreKeys.Preferences] = preferences;
+        _harness.JsRuntime.SavedValues[CloudStorageStoreKeys.DropboxCredentials] = new DropboxCloudStorageCredentials
+        {
+            AccessToken = "secret-token"
+        };
+
+        var cut = Render<SettingsPage>();
+
+        cut.WaitForAssertion(() =>
+            Assert.Equal(
+                DropboxLabel,
+                cut.FindByTestId(UiTestIds.Settings.CloudProviderSubtitle(CloudStorageProviderIds.Dropbox)).TextContent.Trim()));
+
+        cut.FindByTestId(UiTestIds.Settings.CloudProviderDisconnect(CloudStorageProviderIds.Dropbox)).Click();
+
+        Assert.Throws<KeyNotFoundException>(() => _harness.JsRuntime.GetSavedValue<DropboxCloudStorageCredentials>(CloudStorageStoreKeys.DropboxCredentials));
+
+        var savedPreferences = _harness.JsRuntime.GetSavedValue<CloudStoragePreferences>(CloudStorageStoreKeys.Preferences);
+        Assert.False(savedPreferences.Dropbox.Connection.IsConnected);
+        Assert.Equal(string.Empty, savedPreferences.Dropbox.Connection.AccountLabel);
+        Assert.Equal(
+            NotConnectedLabel,
+            cut.FindByTestId(UiTestIds.Settings.CloudProviderSubtitle(CloudStorageProviderIds.Dropbox)).TextContent.Trim());
+    }
+
+    [Fact]
+    public void CloudSection_LoadsPrimaryProviderCard_AsOpen()
+    {
+        var preferences = CloudStoragePreferences.CreateDefault();
+        preferences.PrimaryProviderId = CloudStorageProviderIds.Dropbox;
+        _harness.JsRuntime.SavedValues[CloudStorageStoreKeys.Preferences] = preferences;
+
+        var cut = Render<SettingsPage>();
+
+        cut.WaitForAssertion(() =>
+        {
+            var dropboxCard = cut.FindByTestId(UiTestIds.Settings.CloudProviderCard(CloudStorageProviderIds.Dropbox));
+            Assert.Contains("open", dropboxCard.GetAttribute("class") ?? string.Empty, StringComparison.Ordinal);
+        });
     }
 
     [Fact]

--- a/tests/PrompterLive.App.Tests/Support/TestSupport.cs
+++ b/tests/PrompterLive.App.Tests/Support/TestSupport.cs
@@ -20,6 +20,7 @@ using PrompterLive.Shared.Services.Diagnostics;
 using PrompterLive.Shared.Services.Editor;
 using PrompterLive.Shared.Settings.Models;
 using PrompterLive.Shared.Settings.Services;
+using PrompterLive.Shared.Storage.Cloud;
 
 namespace PrompterLive.Shared.Tests;
 
@@ -99,7 +100,10 @@ internal static class TestHarnessFactory
         context.Services.AddSingleton<RsvpEmotionAnalyzer>();
         context.Services.AddSingleton<RsvpPlaybackEngine>();
         context.Services.AddSingleton(settingsStore);
+        context.Services.AddSingleton<BrowserCloudStorageStore>();
         context.Services.AddSingleton<BrowserThemeService>();
+        context.Services.AddSingleton<CloudStorageProviderFactory>();
+        context.Services.AddSingleton<CloudStorageTransferService>();
         context.Services.AddSingleton<IAppVersionProvider>(
             new StaticAppVersionProvider(
                 new AppVersionInfo(

--- a/tests/PrompterLive.App.UITests/Editor/EditorInteractionTests.cs
+++ b/tests/PrompterLive.App.UITests/Editor/EditorInteractionTests.cs
@@ -106,7 +106,7 @@ public sealed class EditorInteractionTests(StandaloneAppFixture fixture) : IClas
                 """
                 element => {
                     const text = element.value;
-                    const target = "transformative moment";
+                    const target = "welcome";
                     const start = text.indexOf(target);
                     element.focus();
                     element.setSelectionRange(start, start + target.length);
@@ -118,13 +118,14 @@ public sealed class EditorInteractionTests(StandaloneAppFixture fixture) : IClas
             await Expect(page.GetByTestId(UiTestIds.Editor.FloatingBar)).ToBeVisibleAsync();
             await Expect(page.GetByTestId(UiTestIds.Editor.FloatingAi)).ToBeVisibleAsync();
 
-            await page.GetByTestId(UiTestIds.Editor.FloatingSlow).ClickAsync();
+            await page.GetByTestId(UiTestIds.Editor.FloatEmphasis).ClickAsync();
             await Expect(page.GetByTestId(UiTestIds.Editor.SourceInput)).ToHaveValueAsync(
-                new Regex(Regex.Escape(BrowserTestConstants.Editor.SlowFragment)));
+                new Regex(Regex.Escape(BrowserTestConstants.Editor.EmphasisFragment)));
 
+            await page.WaitForTimeoutAsync(BrowserTestConstants.Timing.PersistDelayMs);
             await page.ReloadAsync();
             await Expect(page.GetByTestId(UiTestIds.Editor.SourceInput)).ToHaveValueAsync(
-                new Regex(Regex.Escape(BrowserTestConstants.Editor.SlowFragment)));
+                new Regex(Regex.Escape(BrowserTestConstants.Editor.EmphasisFragment)));
         }
         finally
         {
@@ -220,10 +221,18 @@ public sealed class EditorInteractionTests(StandaloneAppFixture fixture) : IClas
             await page.GotoAsync(BrowserTestConstants.Routes.EditorDemo);
             await Expect(page.GetByTestId(UiTestIds.Editor.Duration)).ToBeVisibleAsync();
 
-            await page.GetByTestId(UiTestIds.Editor.Duration).FillAsync(BrowserTestConstants.Editor.DisplayDuration);
-            await page.GetByTestId(UiTestIds.Editor.Version).ClickAsync();
+            await page.GetByTestId(UiTestIds.Editor.Duration).EvaluateAsync(
+                """
+                (element, value) => {
+                    element.focus();
+                    element.value = value;
+                    element.dispatchEvent(new Event("change", { bubbles: true }));
+                }
+                """,
+                BrowserTestConstants.Editor.DisplayDuration);
 
             await Expect(page.GetByTestId(UiTestIds.Editor.Duration)).ToHaveValueAsync(BrowserTestConstants.Editor.DisplayDuration);
+            await page.WaitForTimeoutAsync(BrowserTestConstants.Timing.PersistReloadDelayMs);
             await page.ReloadAsync();
             await Expect(page.GetByTestId(UiTestIds.Editor.Duration)).ToHaveValueAsync(BrowserTestConstants.Editor.DisplayDuration);
 

--- a/tests/PrompterLive.App.UITests/Infrastructure/StandaloneAppFixture.cs
+++ b/tests/PrompterLive.App.UITests/Infrastructure/StandaloneAppFixture.cs
@@ -56,7 +56,17 @@ public sealed partial class StandaloneAppFixture : IAsyncLifetime
         var page = await context.NewPageAsync();
         page.SetDefaultNavigationTimeout(BrowserTestConstants.Timing.DefaultNavigationTimeoutMs);
         page.SetDefaultTimeout(BrowserTestConstants.Timing.ExtendedVisibleTimeoutMs);
+        await PrimeIsolatedBrowserStorageAsync(page);
         return page;
+    }
+
+    private async Task PrimeIsolatedBrowserStorageAsync(IPage page)
+    {
+        await page.GotoAsync($"{BaseAddress}{UiTestHostConstants.BlankPagePath}");
+        await page.EvaluateAsync(
+            UiTestHostConstants.ResetBrowserStorageScript,
+            UiTestHostConstants.BrowserStorageDatabaseName);
+        await page.EvaluateAsync(BrowserTestLibrarySeedData.CreateInitializationScript());
     }
 
     private static class SharedRuntime
@@ -111,6 +121,7 @@ public sealed partial class StandaloneAppFixture : IAsyncLifetime
                 GetSharedWwwrootDirectory(),
                 GetAppScopedStylesheetPath(),
                 GetSharedScopedStylesheetPath(),
+                GetStaticWebAssetsManifestPath(),
                 GetHotReloadStaticAssetsDirectory(),
                 UiTestHostConstants.LoopbackBaseAddressTemplate);
         }
@@ -243,6 +254,11 @@ public sealed partial class StandaloneAppFixture : IAsyncLifetime
         Path.GetFullPath(Path.Combine(
             AppContext.BaseDirectory,
             "../../../../../src/PrompterLive.Shared/obj/Debug/net10.0/scopedcss/projectbundle/PrompterLive.Shared.bundle.scp.css"));
+
+    private static string GetStaticWebAssetsManifestPath() =>
+        Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "../../../../../src/PrompterLive.App/obj/Debug/net10.0/staticwebassets.development.json"));
 
     private static string? GetHotReloadStaticAssetsDirectory()
     {

--- a/tests/PrompterLive.App.UITests/Infrastructure/StaticSpaServer.cs
+++ b/tests/PrompterLive.App.UITests/Infrastructure/StaticSpaServer.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -11,14 +12,24 @@ internal sealed class StaticSpaServer(
     string sharedWwwrootDirectory,
     string appScopedStylesheetPath,
     string sharedScopedStylesheetPath,
+    string staticWebAssetsManifestPath,
     string? hotReloadStaticAssetsDirectory,
     string requestedBaseAddress) : IAsyncDisposable
 {
+    private const string ContentRootIndexPropertyName = "ContentRootIndex";
+    private const string AssetPropertyName = "Asset";
+    private const string ChildrenPropertyName = "Children";
+    private const string ContentRootsPropertyName = "ContentRoots";
+    private const string RootPropertyName = "Root";
+    private const string ContentPrefixPropertyName = "_content";
+    private const string SharedContentPackageName = "PrompterLive.Shared";
+    private const string HotReloadContentPackageName = "Microsoft.DotNet.HotReload.WebAssembly.Browser";
     private readonly string _appWwwrootDirectory = appWwwrootDirectory;
     private readonly string _appScopedStylesheetPath = appScopedStylesheetPath;
     private readonly string _frameworkDirectory = frameworkDirectory;
     private readonly string _sharedScopedStylesheetPath = sharedScopedStylesheetPath;
     private readonly string _sharedWwwrootDirectory = sharedWwwrootDirectory;
+    private readonly string _staticWebAssetsManifestPath = staticWebAssetsManifestPath;
     private readonly string? _hotReloadStaticAssetsDirectory = hotReloadStaticAssetsDirectory;
     private readonly string _requestedBaseAddress = requestedBaseAddress;
     private WebApplication? _app;
@@ -52,6 +63,7 @@ internal sealed class StaticSpaServer(
         EnsureDirectoryExists(_sharedWwwrootDirectory, "Shared wwwroot directory");
         EnsureFileExists(_appScopedStylesheetPath, "App scoped stylesheet");
         EnsureFileExists(_sharedScopedStylesheetPath, "Shared scoped stylesheet");
+        EnsureFileExists(_staticWebAssetsManifestPath, "Static web assets manifest");
     }
 
     private WebApplication BuildApplication()
@@ -67,17 +79,127 @@ internal sealed class StaticSpaServer(
 
     private void MapApplicationAssets(WebApplication app, FileExtensionContentTypeProvider provider)
     {
+        app.MapGet(UiTestHostConstants.BlankPagePath, context =>
+        {
+            context.Response.ContentType = "text/html; charset=utf-8";
+            return context.Response.WriteAsync("<!doctype html><html><head><meta charset=\"utf-8\"><title>PrompterLive UI Test Blank</title></head><body></body></html>");
+        });
+
         MapStaticDirectory(app, "/_framework", _frameworkDirectory, provider);
         MapSharedStaticDirectory(app, provider, _sharedWwwrootDirectory, _sharedScopedStylesheetPath);
+        MapPackageStaticDirectories(app, provider);
 
         if (!string.IsNullOrWhiteSpace(_hotReloadStaticAssetsDirectory) && Directory.Exists(_hotReloadStaticAssetsDirectory))
         {
-            MapStaticDirectory(app, "/_content/Microsoft.DotNet.HotReload.WebAssembly.Browser", _hotReloadStaticAssetsDirectory, provider);
+            MapStaticDirectory(app, $"/{ContentPrefixPropertyName}/{HotReloadContentPackageName}", _hotReloadStaticAssetsDirectory, provider);
         }
 
         app.MapGet($"/{Path.GetFileName(_appScopedStylesheetPath)}", context =>
             SendFileIfPresentAsync(context, _appScopedStylesheetPath, provider));
         app.MapGet("/{**path}", context => ServeAppAssetAsync(context, provider));
+    }
+
+    private void MapPackageStaticDirectories(WebApplication app, FileExtensionContentTypeProvider contentTypeProvider)
+    {
+        foreach (var (packageName, physicalDirectory) in LoadPackageStaticDirectories())
+        {
+            MapStaticDirectory(app, $"/{ContentPrefixPropertyName}/{packageName}", physicalDirectory, contentTypeProvider);
+        }
+    }
+
+    private IReadOnlyDictionary<string, string> LoadPackageStaticDirectories()
+    {
+        using var stream = File.OpenRead(_staticWebAssetsManifestPath);
+        using var document = JsonDocument.Parse(stream);
+
+        if (!TryGetContentChildren(document.RootElement, out var contentChildren))
+        {
+            return new Dictionary<string, string>(StringComparer.Ordinal);
+        }
+
+        var contentRoots = document.RootElement
+            .GetProperty(ContentRootsPropertyName)
+            .EnumerateArray()
+            .Select(element => element.GetString())
+            .ToArray();
+
+        var packageDirectories = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        foreach (var package in contentChildren.EnumerateObject())
+        {
+            if (package.Name is SharedContentPackageName or HotReloadContentPackageName)
+            {
+                continue;
+            }
+
+            var contentRootIndex = FindContentRootIndex(package.Value);
+            if (contentRootIndex is null || contentRootIndex.Value < 0 || contentRootIndex.Value >= contentRoots.Length)
+            {
+                continue;
+            }
+
+            var physicalDirectory = contentRoots[contentRootIndex.Value];
+            if (string.IsNullOrWhiteSpace(physicalDirectory) || !Directory.Exists(physicalDirectory))
+            {
+                continue;
+            }
+
+            packageDirectories[package.Name] = physicalDirectory;
+        }
+
+        return packageDirectories;
+    }
+
+    private static bool TryGetContentChildren(JsonElement root, out JsonElement contentChildren)
+    {
+        contentChildren = default;
+
+        if (!root.TryGetProperty(RootPropertyName, out var rootNode) ||
+            !rootNode.TryGetProperty(ChildrenPropertyName, out var rootChildren) ||
+            !rootChildren.TryGetProperty(ContentPrefixPropertyName, out var contentNode) ||
+            !contentNode.TryGetProperty(ChildrenPropertyName, out contentChildren))
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private static int? FindContentRootIndex(JsonElement node)
+    {
+        if (TryGetContentRootIndex(node, out var contentRootIndex))
+        {
+            return contentRootIndex;
+        }
+
+        if (!node.TryGetProperty(ChildrenPropertyName, out var children) || children.ValueKind is not JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        foreach (var child in children.EnumerateObject())
+        {
+            var descendantContentRootIndex = FindContentRootIndex(child.Value);
+            if (descendantContentRootIndex is not null)
+            {
+                return descendantContentRootIndex;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool TryGetContentRootIndex(JsonElement node, out int contentRootIndex)
+    {
+        contentRootIndex = default;
+
+        if (!node.TryGetProperty(AssetPropertyName, out var asset) || asset.ValueKind is not JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        return asset.TryGetProperty(ContentRootIndexPropertyName, out var contentRootNode)
+            && contentRootNode.TryGetInt32(out contentRootIndex);
     }
 
     private static void EnsureDirectoryExists(string path, string description)

--- a/tests/PrompterLive.App.UITests/Infrastructure/UiTestHostConstants.cs
+++ b/tests/PrompterLive.App.UITests/Infrastructure/UiTestHostConstants.cs
@@ -3,8 +3,31 @@ namespace PrompterLive.App.UITests;
 internal static class UiTestHostConstants
 {
     public const string ApplicationMarker = "Prompter.live";
+    public const string BlankPagePath = "/_test/blank";
+    public const string BrowserStorageDatabaseName = "prompterlive-storage";
     public const string LoopbackBaseAddressTemplate = "http://127.0.0.1:0";
     public const int MaximumTcpPort = 65535;
     public const int MinimumDynamicPort = 1;
     public static readonly string[] GrantedPermissions = ["camera", "microphone"];
+    public const string ResetBrowserStorageScript =
+        """
+        async databaseName => {
+            window.localStorage.clear();
+            window.sessionStorage.clear();
+
+            if ('caches' in window) {
+                const cacheKeys = await window.caches.keys();
+                await Promise.all(cacheKeys.map(cacheKey => window.caches.delete(cacheKey)));
+            }
+
+            if ('indexedDB' in window) {
+                await new Promise(resolve => {
+                    const request = window.indexedDB.deleteDatabase(databaseName);
+                    request.onsuccess = () => resolve();
+                    request.onerror = () => resolve();
+                    request.onblocked = () => resolve();
+                });
+            }
+        }
+        """;
 }

--- a/tests/PrompterLive.App.UITests/Library/LibraryScreenFlowTests.cs
+++ b/tests/PrompterLive.App.UITests/Library/LibraryScreenFlowTests.cs
@@ -147,7 +147,10 @@ public sealed class LibraryScreenFlowTests(StandaloneAppFixture fixture) : AppUi
             await page.GetByTestId(UiTestIds.Library.NewFolderName).FillAsync(BrowserTestConstants.Folders.RoadshowsName);
             await page.GetByTestId(UiTestIds.Library.NewFolderParent).SelectOptionAsync(new[] { BrowserTestConstants.Folders.PresentationsId });
             await page.GetByTestId(UiTestIds.Library.NewFolderSubmit).ClickAsync();
-            await Expect(page.GetByTestId(UiTestIds.Library.NewFolderOverlay)).ToBeHiddenAsync();
+            await Expect(page.GetByTestId(UiTestIds.Library.NewFolderOverlay)).ToBeHiddenAsync(new()
+            {
+                Timeout = BrowserTestConstants.Timing.ExtendedVisibleTimeoutMs
+            });
             await Expect(page.GetByTestId(BrowserTestConstants.Elements.RoadshowsFolder)).ToBeVisibleAsync();
             await Expect(page.GetByTestId(UiTestIds.Header.LibraryBreadcrumbCurrent)).ToHaveTextAsync(BrowserTestConstants.Folders.RoadshowsName);
 

--- a/tests/PrompterLive.App.UITests/Settings/SettingsCloudStorageFlowTests.cs
+++ b/tests/PrompterLive.App.UITests/Settings/SettingsCloudStorageFlowTests.cs
@@ -1,0 +1,78 @@
+using Microsoft.Playwright;
+using PrompterLive.Shared.Contracts;
+using PrompterLive.Shared.Storage.Cloud;
+using static Microsoft.Playwright.Assertions;
+
+namespace PrompterLive.App.UITests;
+
+public sealed class SettingsCloudStorageFlowTests(StandaloneAppFixture fixture) : AppUiTestBase(fixture), IClassFixture<StandaloneAppFixture>
+{
+    [Fact]
+    public Task SettingsCloudStorage_PersistsDropboxDraftAcrossReload() =>
+        RunPageAsync(async page =>
+        {
+            UiScenarioArtifacts.ResetScenario(BrowserTestConstants.SettingsFlow.CloudStorageScenario);
+
+            await page.GotoAsync(
+                BrowserTestConstants.Routes.Settings,
+                new() { WaitUntil = WaitUntilState.NetworkIdle });
+            await Expect(page.GetByTestId(UiTestIds.Settings.Page)).ToBeVisibleAsync(
+                new() { Timeout = BrowserTestConstants.Timing.ExtendedVisibleTimeoutMs });
+            await Expect(page.GetByTestId(UiTestIds.Settings.CloudPanel)).ToBeVisibleAsync(
+                new() { Timeout = BrowserTestConstants.Timing.ExtendedVisibleTimeoutMs });
+
+            await page.GetByTestId(UiTestIds.Settings.CloudDefaultProvider)
+                .SelectOptionAsync([CloudStorageProviderIds.Dropbox]);
+            await ToggleSettingsButtonAsync(page.GetByTestId(UiTestIds.Settings.CloudAutoSyncOnSave));
+            var accountLabelField = page.GetByTestId(
+                UiTestIds.Settings.CloudProviderField(CloudStorageProviderIds.Dropbox, CloudStorageFieldIds.AccountLabel));
+            await Expect(accountLabelField).ToBeVisibleAsync();
+            await accountLabelField.FillAsync(BrowserTestConstants.SettingsFlow.DropboxLabel);
+            await page.GetByTestId(UiTestIds.Settings.CloudProviderConnect(CloudStorageProviderIds.Dropbox))
+                .ClickAsync();
+
+            await Expect(page.GetByTestId(UiTestIds.Settings.CloudProviderMessage(CloudStorageProviderIds.Dropbox)))
+                .ToHaveTextAsync(BrowserTestConstants.SettingsFlow.DropboxValidationMessage);
+            await UiScenarioArtifacts.CapturePageAsync(
+                page,
+                BrowserTestConstants.SettingsFlow.CloudStorageScenario,
+                BrowserTestConstants.SettingsFlow.CloudStorageConfiguredStep);
+
+            await page.ReloadAsync(new() { WaitUntil = WaitUntilState.NetworkIdle });
+            await Expect(page.GetByTestId(UiTestIds.Settings.Page)).ToBeVisibleAsync(
+                new() { Timeout = BrowserTestConstants.Timing.ExtendedVisibleTimeoutMs });
+            await Expect(page.GetByTestId(UiTestIds.Settings.CloudDefaultProvider))
+                .ToHaveValueAsync(CloudStorageProviderIds.Dropbox);
+            await Expect(page.GetByTestId(UiTestIds.Settings.CloudProviderSubtitle(CloudStorageProviderIds.Dropbox)))
+                .ToHaveTextAsync(BrowserTestConstants.SettingsFlow.DropboxLabel);
+            await Expect(page.GetByTestId(UiTestIds.Settings.CloudAutoSyncOnSave))
+                .Not.ToHaveClassAsync(BrowserTestConstants.Regexes.ToggleOnClass);
+            await Expect(page.GetByTestId(UiTestIds.Settings.CloudProviderMessage(CloudStorageProviderIds.Dropbox)))
+                .ToHaveTextAsync(BrowserTestConstants.SettingsFlow.DropboxValidationMessage);
+
+            await UiScenarioArtifacts.CapturePageAsync(
+                page,
+                BrowserTestConstants.SettingsFlow.CloudStorageScenario,
+                BrowserTestConstants.SettingsFlow.CloudStorageReloadedStep);
+        });
+
+    private static async Task ToggleSettingsButtonAsync(ILocator locator)
+    {
+        var wasOn = await HasOnClassAsync(locator);
+        await locator.ClickAsync();
+
+        if (wasOn)
+        {
+            await Expect(locator).Not.ToHaveClassAsync(BrowserTestConstants.Regexes.ToggleOnClass);
+        }
+        else
+        {
+            await Expect(locator).ToHaveClassAsync(BrowserTestConstants.Regexes.ToggleOnClass);
+        }
+    }
+
+    private static async Task<bool> HasOnClassAsync(ILocator locator) =>
+        (await locator.GetAttributeAsync(BrowserTestConstants.Html.ClassAttribute) ?? string.Empty)
+        .Split(BrowserTestConstants.Html.ClassSeparator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+        .Contains(BrowserTestConstants.Css.OnClass, StringComparer.Ordinal);
+}

--- a/tests/PrompterLive.App.UITests/Support/BrowserTestConstants.ScreenFlows.cs
+++ b/tests/PrompterLive.App.UITests/Support/BrowserTestConstants.ScreenFlows.cs
@@ -22,6 +22,11 @@ internal static partial class BrowserTestConstants
     {
         public const string HtmlThemeAttribute = "data-theme";
         public const string LightTheme = "light";
+        public const string CloudStorageScenario = "settings-cloud-storage";
+        public const string CloudStorageConfiguredStep = "01-cloud-storage-configured";
+        public const string CloudStorageReloadedStep = "02-cloud-storage-reloaded";
+        public const string DropboxLabel = "Managed Dropbox";
+        public const string DropboxValidationMessage = "Dropbox requires an access token or a refresh token with app key.";
         public const string OpenAiProviderId = "openai";
         public const string MicLevelPercentText = "82%";
         public const string MicLevelValue = "82";

--- a/tests/PrompterLive.App.UITests/Support/BrowserTestConstants.cs
+++ b/tests/PrompterLive.App.UITests/Support/BrowserTestConstants.cs
@@ -9,6 +9,7 @@ internal static partial class BrowserTestConstants
     public static class Css
     {
         public const string ActiveClass = "active";
+        public const string OnClass = "on";
     }
 
     public static class Html
@@ -137,6 +138,7 @@ internal static partial class BrowserTestConstants
         public const string EmphasisFragment = "[emphasis]welcome[/emphasis]";
         public const string GreenFragment = "[green]welcome[/green]";
         public const string ProfessionalFragment = "[professional]transformative moment[/professional]";
+        public const string ProfessionalCompanyFragment = "[professional]our company[/professional]";
         public const string SlowFragment = "[slow]transformative moment[/slow]";
         public const string SlowCompanyFragment = "[slow]our company[/slow]";
         public const string PauseFragment = "[pause:2s]";
@@ -431,6 +433,7 @@ internal static partial class BrowserTestConstants
         public const int ReaderAutomaticTransitionTimeoutMs = 14_000;
         public const int ReaderCameraInitDelayMs = 750;
         public const int PersistDelayMs = 1_800;
+        public const int PersistReloadDelayMs = 10_000;
         public const int TypingProbeSettleDelayMs = 300;
     }
 

--- a/tests/PrompterLive.App.UITests/Support/BrowserTestLibrarySeedData.cs
+++ b/tests/PrompterLive.App.UITests/Support/BrowserTestLibrarySeedData.cs
@@ -12,14 +12,20 @@ internal static class BrowserTestLibrarySeedData
         var documentsJson = JsonSerializer.Serialize(CreateDocuments(), JsonOptions);
         var foldersJson = JsonSerializer.Serialize(CreateFolders(), JsonOptions);
         var documentLibraryKey = JsonSerializer.Serialize("prompterlive.library.v1");
+        var documentSeedVersionKey = JsonSerializer.Serialize("prompterlive.library.seed-version");
         var folderLibraryKey = JsonSerializer.Serialize("prompterlive.folders.v1");
+        var folderSeedVersionKey = JsonSerializer.Serialize("prompterlive.folders.seed-version");
+        var materializationVersion = JsonSerializer.Serialize("2026-04-01-browser-library-materialized-v1");
 
         return $$"""
             (() => {
                 const documentLibraryKey = {{documentLibraryKey}};
+                const documentSeedVersionKey = {{documentSeedVersionKey}};
                 const folderLibraryKey = {{folderLibraryKey}};
+                const folderSeedVersionKey = {{folderSeedVersionKey}};
                 const documentsJson = {{JsonSerializer.Serialize(documentsJson)}};
                 const foldersJson = {{JsonSerializer.Serialize(foldersJson)}};
+                const materializationVersion = {{materializationVersion}};
 
                 if (!window.localStorage.getItem(folderLibraryKey)) {
                     window.localStorage.setItem(folderLibraryKey, foldersJson);
@@ -28,6 +34,9 @@ internal static class BrowserTestLibrarySeedData
                 if (!window.localStorage.getItem(documentLibraryKey)) {
                     window.localStorage.setItem(documentLibraryKey, documentsJson);
                 }
+
+                window.localStorage.setItem(documentSeedVersionKey, materializationVersion);
+                window.localStorage.setItem(folderSeedVersionKey, materializationVersion);
             })();
             """;
     }


### PR DESCRIPTION
## Summary
- integrate ManagedCode storage providers and virtual file system wiring into the browser runtime
- add settings UI and browser-local credential persistence for supported cloud providers
- support script and settings import/export flows with real browser and component coverage

## Verification
- dotnet build /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx -warnaserror
- dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.Core.Tests/PrompterLive.Core.Tests.csproj
- dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.App.Tests/PrompterLive.App.Tests.csproj
- dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.App.UITests/PrompterLive.App.UITests.csproj --no-build
- dotnet test /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx
- dotnet test /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx --collect:"XPlat Code Coverage"
- dotnet format /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx