### PR TITLE
Implement real Go Live studio runtime

### DIFF
--- a/docs/ADR/ADR-0002-go-live-operational-studio-surface.md
+++ b/docs/ADR/ADR-0002-go-live-operational-studio-surface.md
@@ -1,0 +1,162 @@
+# ADR-0002: Go Live Operational Studio Surface
+
+Status: Implemented  
+Date: 2026-04-01  
+Related Features: [Go Live Runtime](/Users/ksemenenko/Developer/PrompterLive/docs/Features/GoLiveRuntime.md), [Architecture Overview](/Users/ksemenenko/Developer/PrompterLive/docs/Architecture.md)
+
+## Implementation plan (step-by-step)
+
+- [x] Audit the existing routed `Go Live` page against `new-design/golive.html`.
+- [x] Replace the design drifted routing form layout with a studio shell that matches the design rails and canvas.
+- [x] Bind the studio shell to real browser media state, real scene cameras, and honest destination readiness summaries.
+- [x] Keep detailed provider setup in `Settings` and reduce `Go Live` to operational toggles plus links back to setup.
+- [x] Add component and browser coverage for source selection, take-to-air, destination arming, and deterministic browser media behavior.
+- [x] Update architecture and feature documentation to reflect the new boundary.
+
+## Context
+
+- The prior `Go Live` page mixed an operational studio surface with a large lower deck of inline provider forms.
+- That shape diverged from `new-design/golive.html`, pushed the most important controls below the fold, and encouraged duplicate ownership of provider credentials between `Go Live` and `Settings`.
+- The product already has browser media services, scene state, output runtime services, and persisted provider settings. The problem was not missing capability; it was a blurred page contract.
+- The user explicitly asked for a real `Go Live` studio with camera switching, live preview, honest data, and design fidelity instead of a fake or placeholder surface.
+
+Goals:
+
+- Keep `Go Live` visually faithful to `new-design/golive.html`.
+- Make `Go Live` operational, not administrative.
+- Keep live status, room state, and destination readiness truthful to what the browser runtime actually knows.
+- Cover the main studio flow with automated component and browser tests.
+
+Non-goals:
+
+- Adding new server-side relay infrastructure.
+- Moving provider credential editing out of `Settings`.
+- Inventing packet-loss, guest, or network telemetry that the browser runtime does not own.
+
+## Decision
+
+`Go Live` becomes the operational studio surface for the current scene, while `Settings` remains the only page that edits provider credentials, ingest endpoints, and detailed device or streaming configuration.
+
+Key points:
+
+- The routed `Go Live` page now mirrors the design shell with a top session bar, left input rail, center program monitor, scene control strip, and right live/studio rail.
+- The center monitor shows the currently selected program source. The right preview rail shows the currently on-air source until the operator takes the selected source live.
+- Destination cards in the right rail only arm or disarm persisted targets and show honest readiness summaries derived from stored settings and runtime availability.
+- If the browser exposes cameras and the scene is empty, `Go Live` seeds the first available camera so the studio does not boot into a dead state.
+- Fake guest lists, fake people, and invented runtime metrics are removed. The room panel may show local-host state and persisted room identity only when no real guest transport exists.
+
+## Diagram
+
+```mermaid
+flowchart LR
+    Settings["SettingsPage<br/>devices + provider setup"]
+    GoLive["GoLivePage<br/>operational studio"]
+    Sources["GoLiveSourcesCard"]
+    Program["GoLiveProgramFeedCard"]
+    Controls["GoLiveSceneControls"]
+    Preview["GoLiveCameraPreviewCard"]
+    Sidebar["GoLiveStudioSidebar"]
+    Studio["StudioSettingsStore"]
+    Scene["IMediaSceneService"]
+    Runtime["GoLiveOutputRuntimeService"]
+
+    Settings --> Studio
+    Settings --> Scene
+    Settings --> GoLive
+    GoLive --> Sources
+    GoLive --> Program
+    GoLive --> Controls
+    GoLive --> Preview
+    GoLive --> Sidebar
+    GoLive --> Studio
+    GoLive --> Scene
+    GoLive --> Runtime
+```
+
+## Alternatives considered
+
+### Keep provider forms inside `Go Live`
+
+- Pros: fewer clicks for provider editing.
+- Cons: duplicates `Settings` ownership, keeps the studio surface bloated, and continues the design mismatch.
+- Rejected because it preserves the exact ambiguity that caused the current UI drift.
+
+### Build a design-faithful shell but populate it with placeholder data
+
+- Pros: fast visual parity.
+- Cons: violates the product requirement for honest browser-backed state and would make tests prove a fake flow.
+- Rejected because `Go Live` is an operational screen, not a mockup.
+
+### Move all live controls into `Settings`
+
+- Pros: one page for every live concern.
+- Cons: destroys the operational studio workflow and breaks the design reference.
+- Rejected because the user needs a dedicated live-production surface.
+
+## Consequences
+
+### Positive
+
+- `Go Live` now reads like a studio surface instead of a settings form.
+- Runtime ownership is clearer: `Settings` configures providers, `Go Live` operates them.
+- Source switching and take-to-air behavior are easier to reason about and test.
+- The page no longer renders fake people or fabricated provider/network state.
+
+### Negative / risks
+
+- Operators must leave `Go Live` for deep provider edits.
+  Mitigation: destination cards link directly to `Settings`, and the right rail explains that detailed setup lives there.
+- Browser runtime metrics remain limited compared to a server relay.
+  Mitigation: the UI shows honest summaries and avoids pretending the browser has relay telemetry.
+- Auto-seeding a default camera changes empty-scene boot behavior.
+  Mitigation: this only happens when the scene is empty and real browser cameras are available, which avoids a dead operational surface.
+
+## Impact
+
+### Code
+
+- Affected modules and services:
+  - `src/PrompterLive.Shared/GoLive/Pages/*`
+  - `src/PrompterLive.Shared/GoLive/Components/*`
+  - `src/PrompterLive.Shared/Contracts/UiTestIds.cs`
+  - `tests/PrompterLive.App.Tests/GoLive/GoLivePageTests.cs`
+  - `tests/PrompterLive.App.UITests/GoLive/GoLiveFlowTests.cs`
+  - `tests/PrompterLive.App.UITests/Scenarios/StudioWorkflowScenarioTests.cs`
+- New boundaries and responsibilities:
+  - `GoLivePage` owns the operational studio layout and quick toggles.
+  - `Settings` owns provider configuration and detailed streaming setup.
+  - `GoLiveStudioSidebar` summarizes provider readiness but does not edit secrets or ingest fields.
+
+### Documentation
+
+- [docs/Features/GoLiveRuntime.md](/Users/ksemenenko/Developer/PrompterLive/docs/Features/GoLiveRuntime.md) now documents the operational-studio boundary.
+- [docs/Architecture.md](/Users/ksemenenko/Developer/PrompterLive/docs/Architecture.md) now maps `Go Live` and `Settings` responsibilities more explicitly.
+
+## Verification
+
+### Testing methodology
+
+- Prove the compact studio layout through routed component tests.
+- Prove browser-realistic source selection, take-to-air, and destination arming through deterministic Playwright media flows.
+- Keep screenshot artifacts for the main studio scenario under `output/playwright/`.
+
+### Test commands
+
+- `dotnet build /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx -warnaserror`
+- `dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.App.Tests/PrompterLive.App.Tests.csproj --filter "FullyQualifiedName~GoLivePageTests"`
+- `dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.App.UITests/PrompterLive.App.UITests.csproj --filter "FullyQualifiedName~GoLiveFlowTests"`
+- `dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.App.UITests/PrompterLive.App.UITests.csproj --filter "FullyQualifiedName~StudioWorkflow_SettingsAndGoLiveStudio_CapturesArtifacts"`
+
+### New or changed tests
+
+| ID | Scenario | Level | Expected result |
+| --- | --- | --- | --- |
+| TST-001 | Open `Go Live` with persisted destinations | Component | Ready summaries render from persisted settings without inline provider forms |
+| TST-002 | Select the secondary camera and take it live | UI | Program monitor switches first, live preview switches only after take-to-air |
+| TST-003 | Arm LiveKit, YouTube, OBS, and recording from the studio surface | UI | Quick toggles persist and reload into the operational studio |
+
+## References
+
+- [new-design/golive.html](/Users/ksemenenko/Developer/PrompterLive/new-design/golive.html)
+- [docs/Features/GoLiveRuntime.md](/Users/ksemenenko/Developer/PrompterLive/docs/Features/GoLiveRuntime.md)
+- [docs/Architecture.md](/Users/ksemenenko/Developer/PrompterLive/docs/Architecture.md)

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -95,8 +95,8 @@ flowchart LR
 | `Editor` | TPS authoring surface | Creates and reshapes scripts with structure-aware tooling | `src/PrompterLive.Shared/Editor`, `src/PrompterLive.Core/Editor`, `src/PrompterLive.Core/Tps` | source editing UI, toolbar actions, front matter, TPS transforms | shell navigation policy, teleprompter playback, live runtime wiring |
 | `Learn` | RSVP rehearsal mode | Trains delivery with timing and context | `src/PrompterLive.Shared/Learn`, `src/PrompterLive.Core/Rsvp` | ORP playback, rehearsal pacing, next-phrase context | document storage, scene routing, destination configuration |
 | `Teleprompter` | Read-mode playback surface | Presents the script for live reading with camera-backed composition | `src/PrompterLive.Shared/Teleprompter` | reading layout, background camera composition, runtime reading flow | script persistence rules, destination setup screens |
-| `GoLive` | Live production and routing surface | Arms outputs, switches sources, previews cameras, and exposes live telemetry | `src/PrompterLive.Shared/GoLive`, `src/PrompterLive.Core/Streaming` | studio layout, output controls, destination routing, live session state | server-side stream processing, unrelated editor or library concerns |
-| `Settings` | Device and scene setup surface | Configures cameras, microphones, overlays, and base scene state | `src/PrompterLive.Shared/Settings`, `src/PrompterLive.Core/Media` | device selection UI, scene transforms, scene persistence flows | live output orchestration policy, document editing |
+| `GoLive` | Operational browser studio surface | Arms outputs, switches sources, previews cameras, and exposes honest live/runtime status | `src/PrompterLive.Shared/GoLive`, `src/PrompterLive.Core/Streaming` | studio layout, output quick toggles, selected vs on-air source state, live session state | provider credential editing, server-side stream processing, unrelated editor or library concerns |
+| `Settings` | Device, scene, and provider setup surface | Configures cameras, microphones, overlays, base scene state, and persisted destination credentials | `src/PrompterLive.Shared/Settings`, `src/PrompterLive.Core/Media` | device selection UI, scene transforms, provider credentials/endpoints, scene persistence flows | live output orchestration policy, document editing |
 | `Storage` | Browser persistence and cloud transfer orchestration | Keeps scripts and settings local-first while exposing provider-backed import/export | `src/PrompterLive.Shared/Storage`, `src/PrompterLive.Shared/Library/Services/Storage` | browser `IStorage` and VFS registration, authoritative browser repositories for scripts/folders, provider credential persistence, scripts/settings snapshot transfer | routed page layout, teleprompter rendering, video-stream upload workflows |
 | `Diagnostics` | Error and operation feedback layer | Makes recoverable and fatal issues visible in the shell | `src/PrompterLive.Shared/Diagnostics` | banners, error boundary reporting, operation status wiring | owning business logic of the failing feature |
 | `Localization` | Culture and UI text contract | Keeps supported runtime languages consistent and browser-driven | `src/PrompterLive.Shared/Localization`, `src/PrompterLive.Core/Localization` | text catalogs, culture bootstrap, supported culture rules | feature behavior or screen-specific layout ownership |
@@ -391,16 +391,16 @@ sequenceDiagram
 
 ```mermaid
 flowchart LR
-    Settings["SettingsPage<br/>device setup only"]
-    GoLive["GoLivePage<br/>studio layout + destination routing"]
+    Settings["SettingsPage<br/>devices + provider setup"]
+    GoLive["GoLivePage<br/>operational studio surface"]
     SessionBar["GO Live session bar<br/>back, title, timer, record, stream"]
-    PreviewRail["preview + stats rail"]
+    PreviewRail["preview + studio rail"]
     Preview["GoLiveCameraPreviewCard"]
     Program["GoLiveProgramFeedCard"]
     Sources["GoLiveSourcesCard"]
-    TargetSources["GoLiveDestinationSourcePicker"]
+    SceneControls["GoLiveSceneControls"]
+    Sidebar["GoLiveStudioSidebar"]
     Studio["StudioSettingsStore"]
-    Routing["GoLiveDestinationRouting"]
     Scene["IMediaSceneService"]
     CameraInterop["CameraPreviewInterop"]
     Providers["IStreamingOutputProvider[]"]
@@ -411,7 +411,6 @@ flowchart LR
     Settings --> GoLive
     GoLive --> Studio
     GoLive --> Scene
-    GoLive --> Routing
     GoLive --> Providers
     GoLive --> Reader
     GoLive --> SessionBar
@@ -419,11 +418,14 @@ flowchart LR
     GoLive --> Preview
     GoLive --> Program
     GoLive --> Sources
-    GoLive --> TargetSources
+    GoLive --> SceneControls
+    GoLive --> Sidebar
     Preview --> CameraInterop
     Preview --> Scene
-    Routing --> Studio
-    Routing --> Scene
+    Sidebar --> Studio
+    Sidebar --> Providers
+    Sources --> Scene
+    SceneControls --> Scene
 ```
 
 ```mermaid

--- a/docs/Features/GoLiveRuntime.md
+++ b/docs/Features/GoLiveRuntime.md
@@ -2,18 +2,21 @@
 
 ## Scope
 
-`Go Live` is the dedicated browser-only routing surface for arming live destinations.
+`Go Live` is the dedicated browser-only operational studio surface for switching real scene inputs, previewing the current on-air camera, and arming live destinations that are already configured in browser storage.
 
 The current page layout is a production-style studio surface:
 
 - top session bar for back, title, timer, record, and stream controls
-- left source rail for scene cameras and session shortcuts
-- center program stage for the active script and selected/program source state
-- right rail for live preview plus stream, audio, and network telemetry
-- lower routing decks for local outputs and cloud destinations
+- left input rail for scene cameras, add-camera action, utility sources, and microphone route status
+- center program stage for the selected program source and current script/session state
+- scene controls bar for selecting the active studio mode and taking the selected source to air
+- right rail for the current live preview plus compact stream, audio, and room/runtime panels
+- destination cards that arm OBS, recording, LiveKit, and YouTube from persisted settings instead of editing credentials inline
 
 The runtime now owns real browser media outputs for the composed program scene and the current audio bus:
 
+- `Go Live` auto-seeds the first available browser camera into the scene when the scene is empty and the browser exposes a real camera list
+- the center program stage always shows the currently selected scene camera, while the right preview rail shows the currently on-air camera until the operator takes the selected source live
 - `Go Live` builds one browser-side program stream from the scene camera cards by drawing the selected primary camera full-frame and then layering additional included cameras as positioned overlays on a canvas
 - the scene `AudioBus` is mixed into one program audio track through `AudioContext`, delay, and gain nodes before the final program stream is published or recorded
 - OBS browser output stays browser-only and exposes the composed program audio inside an OBS Browser Source environment
@@ -26,11 +29,13 @@ The runtime now owns real browser media outputs for the composed program scene a
 Relay-only destinations stay configuration surfaces:
 
 - YouTube, Twitch, custom RTMP, and similar RTMP-style targets still persist credentials and routing in browser storage
+- `Go Live` only exposes quick arm/disarm toggles and readiness summaries for those targets
+- detailed destination credentials, ingest URLs, and provider-specific configuration live in `Settings`
 - these targets do not publish directly from the browser runtime; they require an external relay or ingest layer outside this standalone WASM app
 
 It is separate from:
 
-- `Settings`, which owns device setup such as camera selection, resolution, FPS, microphones, and audio sync
+- `Settings`, which owns device setup, provider credentials, ingest endpoints, and other detailed studio configuration such as camera selection, resolution, FPS, microphones, and audio sync
 - `Teleprompter`, which owns the read experience and can run alongside the armed live configuration
 
 ## Main Flow
@@ -40,8 +45,10 @@ sequenceDiagram
     participant User
     participant Settings as "SettingsPage"
     participant GoLive as "GoLivePage"
+    participant Sources as "GoLiveSourcesCard"
+    participant Controls as "GoLiveSceneControls"
     participant Preview as "GoLiveCameraPreviewCard"
-    participant Routing as "GoLiveDestinationRouting"
+    participant Sidebar as "GoLiveStudioSidebar"
     participant Studio as "StudioSettingsStore"
     participant Scene as "IMediaSceneService"
     participant Runtime as "GoLiveOutputRuntimeService"
@@ -52,15 +59,20 @@ sequenceDiagram
     User->>Settings: Configure camera, FPS, mic, sync
     Settings->>Studio: Persist device preferences
     Settings->>Scene: Persist scene cameras and audio bus
+    User->>Settings: Configure LiveKit / YouTube / recording settings
+    Settings->>Studio: Persist provider credentials and destinations
     User->>GoLive: Open Go Live
     GoLive->>Studio: Load live routing settings
     GoLive->>Scene: Load current scene sources
-    GoLive->>Routing: Normalize destination source selections
-    GoLive->>Preview: Mount the first included scene camera
-    GoLive->>Providers: Describe LiveKit / VDO.Ninja / RTMP readiness
+    GoLive->>Sources: Render real scene cameras and mic status
+    GoLive->>Preview: Mount the current on-air scene camera
+    GoLive->>Sidebar: Summarize persisted destination readiness
     User->>GoLive: Arm one or more destinations
-    User->>GoLive: Select scene cameras per destination
     GoLive->>Studio: Persist output targets
+    User->>Sources: Select a different scene camera
+    Sources->>GoLive: Update selected program source
+    User->>Controls: Take selected source to air
+    Controls->>GoLive: Promote selected source to active source
     User->>GoLive: Start stream
     GoLive->>Runtime: Build request from scene snapshot + audio bus + recording export prefs
     Runtime->>Browser: Start or update browser output session
@@ -82,13 +94,13 @@ sequenceDiagram
 flowchart LR
     Page["GoLivePage"]
     SessionBar["session bar"]
-    PreviewRail["preview + telemetry rail"]
+    PreviewRail["preview + studio rail"]
     Preview["GoLiveCameraPreviewCard"]
     Program["GoLiveProgramFeedCard"]
     Sources["GoLiveSourcesCard"]
-    TargetSources["GoLiveDestinationSourcePicker"]
+    SceneControls["GoLiveSceneControls"]
+    Sidebar["GoLiveStudioSidebar"]
     Studio["StreamStudioSettings"]
-    Routing["GoLiveDestinationRouting"]
     Scene["MediaSceneState"]
     AudioBus["AudioBusState"]
     CameraInterop["CameraPreviewInterop"]
@@ -108,9 +120,9 @@ flowchart LR
     Page --> Preview
     Page --> Program
     Page --> Sources
-    Page --> TargetSources
+    Page --> SceneControls
+    Page --> Sidebar
     Page --> Studio
-    Page --> Routing
     Page --> Scene
     Page --> AudioBus
     Page --> Runtime
@@ -162,14 +174,16 @@ flowchart LR
 ## Rules
 
 - `Settings` must not own live destination routing anymore.
+- `Settings` owns provider credentials, ingest endpoints, and detailed streaming configuration. `Go Live` may only arm or disarm those persisted targets and link back to `Settings` for setup.
 - `Settings` must expose a visible CTA into `Go Live` so device setup and live routing stay discoverable as separate flows.
 - the shared header shell must keep `Go Live` reachable from every non-`Go Live` routed page because it is a primary studio action
 - `Go Live` may arm multiple destinations at the same time.
 - `Go Live` must reuse the browser-composed scene and not invent a separate media graph.
-- `Go Live` must show a live camera preview inside the program feed area, using the first included scene camera and falling back to the first visible scene camera.
+- `Go Live` must auto-seed the first available browser camera into the scene when the scene is empty and devices are available.
+- `Go Live` must show the selected program source in the center monitor and the currently on-air source in the right preview rail until the operator explicitly takes the selected source live.
 - `Go Live` must show a stable empty preview state instead of mounting camera interop when the current scene has no cameras.
 - any shared `Go Live` localized copy must come from `PrompterLive.Shared.Localization.UiTextCatalog`, so supported browser cultures localize the studio surface without feature-local string copies.
-- each live destination must persist its own selected scene cameras, independent of the shared program feed source list
+- quick destination cards must only expose honest readiness summaries and arm/disarm toggles; fake in-page credential editors are forbidden on the operational studio surface
 - legacy streaming settings must normalize to the current included program cameras so existing browser storage keeps working
 - `VirtualCamera` mode normalizes to OBS armed by default, so browser sessions keep the legacy desktop-capture workflow unless the user explicitly turns OBS off
 - Camera source inclusion is persisted through `MediaSceneState`.

--- a/go-live-director-runtime.plan.md
+++ b/go-live-director-runtime.plan.md
@@ -1,0 +1,163 @@
+# Go Live Director Runtime Plan
+
+## Goal
+
+Port the full `new-design/golive.html` studio screen into the routed Blazor `Go Live` feature with real browser-backed media/runtime behavior, honest live status data, real camera and microphone switching flows, updated architecture/ADR documentation, and browser-first automated coverage.
+
+## Scope
+
+### In Scope
+
+- Rebuild the routed `Go Live` screen to match `new-design/golive.html` layout, structure, and interaction intent.
+- Use real browser media state for camera cards, selected/program source, microphone state, live/record state, and timer-driven status.
+- Wire the `Go Live` screen to actual scene cameras, microphones, destination arming, and runtime session state that already live in browser storage and media services.
+- Ensure source switching, scene selection, panel toggles, and session controls update the real program/runtime state instead of static demo labels.
+- Add or update an ADR and feature/architecture docs when the ownership or runtime contract changes.
+- Add or update component and browser tests that prove the design-shaped flow with deterministic browser media.
+
+### Out Of Scope
+
+- Backend relay infrastructure or server-side transcoding.
+- New external streaming providers beyond the browser-only/runtime contracts already modeled in the repo.
+- Recorded video upload workflows beyond documenting how the `Go Live` runtime will align with the existing browser/cloud-storage direction.
+
+## Constraints And Risks
+
+- The routed UI must stay faithful to `new-design/golive.html`; partial approximation is not acceptable.
+- Browser tests must keep using the deterministic synthetic media harness; no hardware dependency may leak into CI.
+- `Go Live` already has runtime services and docs; the task must refine that ownership instead of introducing a parallel implementation path.
+- Any fake telemetry, fake participants, or fake room state in the right rail must be removed or replaced by honest runtime state.
+- `data-testid` hooks must remain stable and new ones must be added in shared contracts for any new acceptance coverage.
+- Editor/teleprompter/storage work from prior tasks must not regress while reshaping cross-cutting media/runtime services.
+
+## Testing Methodology
+
+- Start with the existing `GoLive` component and browser suites to establish the real baseline.
+- Add failing component tests for the design-accurate routed structure and runtime-driven status rendering.
+- Add failing browser coverage for the main studio flow: open `Go Live`, verify real synthetic camera cards, switch program source, arm outputs, start/stop live session, and verify visual/runtime state changes.
+- Capture major browser scenario screenshots under `output/playwright/`.
+- Use the repo validation order: build, focused tests, browser suite, broader regression suite, coverage, format.
+
+## Ordered Plan
+
+- [x] Step 1. Inspect the current `Go Live` runtime against the design reference and identify exact deltas.
+  - Compare `new-design/golive.html` and `styles-golive.css` with the current Blazor page, components, CSS, and existing feature docs.
+  - Enumerate which existing cards/rails already map cleanly and which need markup/layout replacement, renamed state, or new contracts.
+  - Verification before moving on:
+    - A concrete delta list exists in working notes and the implementation path is scoped to `GoLive`, `Media`, and any shared contracts that truly need adjustment.
+
+- [x] Step 2. Run the relevant baseline verification before production changes.
+  - Run:
+    - `dotnet build /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx -warnaserror`
+    - `dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.App.Tests/PrompterLive.App.Tests.csproj`
+    - `dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.App.UITests/PrompterLive.App.UITests.csproj --no-build`
+  - Track any failing test explicitly under `## Baseline Failures` before fixing code.
+  - Verification before moving on:
+    - Baseline status is recorded and any inherited failure has a root-cause note and a fix path.
+
+- [x] Step 3. Reshape the routed `Go Live` page and child components to match the design shell.
+  - Rework `GoLivePage.razor`, child components, and feature CSS so the top bar, inputs panel, center canvas/program area, scenes bar, and right studio/info rail reflect `new-design/golive.html`.
+  - Move or split markup into focused components only where that preserves parity and keeps files under repo limits.
+  - Add/update shared UI test ids for new stable landmarks and interactions.
+  - Verification before moving on:
+    - The rendered structure mirrors the design sections.
+    - No implementation literals or brittle selectors are introduced.
+  - Completed evidence:
+    - `GoLivePage.razor` now renders the compact top bar, left inputs rail, center stage, scene controls, and right live/studio rail instead of the old lower routing deck.
+    - `GoLiveSourcesCard`, `GoLiveProgramFeedCard`, `GoLiveCameraPreviewCard`, `GoLiveSceneControls`, and `GoLiveStudioSidebar` were reshaped to match the design-owned studio shell.
+    - Shared test id contracts were extended with `UiTestIds.GoLive.AddSource`.
+
+- [x] Step 4. Replace placeholder/demo state with honest browser/runtime-driven `Go Live` data.
+  - Audit `GoLivePage` partials, `GoLiveSessionService`, runtime services, and any right-rail models to remove fake personas, fake telemetry, and stale demo copy.
+  - Bind camera/source cards, microphone routing labels, timer/status badges, and runtime panels to real `IMediaSceneService`, `IScriptSessionService`, and `GoLiveOutputRuntimeService` state.
+  - Ensure empty/disabled states are explicit and honest when the browser runtime does not own a metric.
+  - Verification before moving on:
+    - The page renders only truthful runtime or persisted configuration state.
+    - There are no hardcoded fake guests or fabricated network values in `GoLive`.
+  - Completed evidence:
+    - Fake team/guest-style content was removed from the `Go Live` surface.
+    - Destination summaries now derive from real persisted `StudioSettings` readiness instead of inline placeholder fields.
+    - The room and runtime tabs render honest local-host and available-runtime state only.
+
+- [x] Step 5. Tighten real browser media and live control behavior.
+  - Verify and fix source switching, scene selection, input arming, record/live toggles, and program monitor updates so they drive the browser runtime correctly.
+  - Ensure selected camera/program state propagates through the live output request factory/runtime and updates the page immediately.
+  - Fix any camera/microphone switching gaps that prevent the design-shaped controls from affecting the actual program/output state.
+  - Verification before moving on:
+    - Switching sources and toggling live/record state changes the runtime session state and visible program/preview indicators.
+    - Real synthetic camera/mic data are used in browser flows without regressions.
+  - Completed evidence:
+    - `GoLivePage.Bootstrap.cs` now auto-seeds the first available camera into an empty scene.
+    - `GoLivePage.Actions.cs` adds the next available browser camera from the real media-device list.
+    - The center monitor now tracks the selected source while the right preview rail tracks the on-air source until `TakeToAir`.
+
+- [x] Step 6. Add failing tests for the new contracts, then make them pass.
+  - Add or update bUnit tests under `tests/PrompterLive.App.Tests/GoLive/` for the design-shaped top bar, rails, source/program status, and honest runtime info.
+  - Add or update Playwright tests under `tests/PrompterLive.App.UITests/GoLive/` for the full director/studio flow with deterministic media, including screenshots under `output/playwright/`.
+  - Keep constants and selectors in shared contracts/test constants rather than inline literals.
+  - Verification before moving on:
+    - New or updated tests fail before the code fix and pass after the implementation.
+    - Browser coverage proves real interactions, not just static DOM.
+  - Completed evidence:
+    - `dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.App.Tests/PrompterLive.App.Tests.csproj --filter "FullyQualifiedName~GoLivePageTests"` passed with `7/7`.
+    - `dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.App.UITests/PrompterLive.App.UITests.csproj --filter "FullyQualifiedName~GoLiveFlowTests"` passed with `10/10`.
+    - `dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.App.UITests/PrompterLive.App.UITests.csproj --filter "FullyQualifiedName~StudioWorkflow_SettingsAndGoLiveStudio_CapturesArtifacts"` passed with `1/1`.
+
+- [x] Step 7. Update docs and record the runtime/design decision.
+  - Update `docs/Features/GoLiveRuntime.md` if the flow, runtime honesty policy, or contracts changed.
+  - Add/update an ADR under `docs/ADR/` covering the design-faithful browser studio surface and the decision to keep `Go Live` truthful to real browser media/runtime state.
+  - Update `docs/Architecture.md` if the ownership map or cross-slice boundaries changed.
+  - Verification before moving on:
+    - ADR and feature docs contain valid Mermaid diagrams.
+    - Architecture guidance stays aligned with the implemented runtime.
+  - Completed evidence:
+    - `docs/Features/GoLiveRuntime.md` now documents the operational studio boundary and source-selection flow.
+    - `docs/Architecture.md` now reflects that `Settings` owns provider setup while `Go Live` owns operational arming and switching.
+    - `docs/ADR/ADR-0002-go-live-operational-studio-surface.md` records the design/runtime decision with Mermaid diagrams.
+
+- [x] Step 8. Run final validation and prepare the change for shipping.
+  - Run the final validation in order:
+    - `dotnet build /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx -warnaserror`
+    - `dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.App.Tests/PrompterLive.App.Tests.csproj`
+    - `dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.App.UITests/PrompterLive.App.UITests.csproj --no-build`
+    - `dotnet test /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx`
+    - `dotnet test /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx --collect:"XPlat Code Coverage"`
+    - `dotnet format /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx`
+  - Review the final diff for intentionality and update this plan with the completed validation evidence.
+  - Verification before moving on:
+    - All relevant tests are green.
+    - The working tree contains only intentional `Go Live` task changes.
+  - Completed evidence:
+    - `dotnet build /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx -warnaserror` passed before and after the final cleanup pass.
+    - `dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.App.Tests/PrompterLive.App.Tests.csproj` passed with `100/100`.
+    - `dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.App.UITests/PrompterLive.App.UITests.csproj --no-build` passed with `79/79`.
+    - `dotnet test /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx` passed with `34` core tests, `100` app tests, and `79` UI tests green.
+    - `dotnet test /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx --collect:"XPlat Code Coverage"` passed and emitted fresh Cobertura reports for core, app, and UI suites.
+    - `dotnet format /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx` completed successfully; the only console note was the existing `IDE0060` no-code-fix message, which did not fail the command.
+
+## Baseline Failures
+
+- [x] No pre-existing baseline failures in the relevant build, component, or browser suites.
+  - Build: `dotnet build /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx -warnaserror` passed.
+  - App tests: `dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.App.Tests/PrompterLive.App.Tests.csproj` passed with `100/100`.
+  - UI tests: `dotnet test /Users/ksemenenko/Developer/PrompterLive/tests/PrompterLive.App.UITests/PrompterLive.App.UITests.csproj --no-build` passed with `77/77`.
+  - Root-cause note: the current baseline is stable enough to start failing-forward on `Go Live` without inherited product failures.
+  - Fix status: no baseline failures to clear before implementation.
+
+## Final Validation Skills
+
+- `dotnet-blazor`
+  - Reason: keep the `Go Live` routed surface and component state aligned with the Blazor WASM ownership model.
+  - Expected outcome: component-first implementation with minimal JS interop and correct state flow.
+
+- `mcaf-testing`
+  - Reason: add browser-first and component coverage for the full director/studio flow.
+  - Expected outcome: meaningful tests for design structure, runtime honesty, and real media interaction.
+
+- `mcaf-adr-writing`
+  - Reason: record the design-faithful browser studio runtime decision and its trade-offs.
+  - Expected outcome: an ADR with concrete alternatives, consequences, and verification strategy.
+
+- `playwright`
+  - Reason: verify the complete `Go Live` experience with deterministic synthetic media in a real browser.
+  - Expected outcome: passing end-to-end browser flow with screenshot artifacts.

--- a/src/PrompterLive.Shared/Contracts/UiTestIds.cs
+++ b/src/PrompterLive.Shared/Contracts/UiTestIds.cs
@@ -339,6 +339,7 @@ public static class UiTestIds
     public static class GoLive
     {
         public const string ActiveSourceLabel = "go-live-active-source-label";
+        public const string AddSource = "go-live-add-source";
         public const string AudioMixer = "go-live-audio-mixer";
         public const string Bitrate = "go-live-bitrate";
         public const string CreateRoom = "go-live-create-room";

--- a/src/PrompterLive.Shared/GoLive/Components/GoLiveCameraPreviewCard.razor.css
+++ b/src/PrompterLive.Shared/GoLive/Components/GoLiveCameraPreviewCard.razor.css
@@ -1,41 +1,50 @@
 .go-live-preview-shell {
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: 10px;
     padding: 10px;
-    border: 1px solid rgba(214, 166, 91, .08);
-    border-radius: 22px;
-    background: rgba(6, 9, 18, .88);
+    border: 1px solid rgba(255, 255, 255, .06);
+    border-radius: 18px;
+    background: rgba(8, 11, 18, .78);
 }
 
 .go-live-preview-heading {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 10px;
-    padding: 4px 2px 0;
+    gap: 12px;
 }
 
 .go-live-preview-stage {
     position: relative;
     overflow: hidden;
-    min-height: 112px;
-    border: 1px solid rgba(214, 166, 91, .06);
-    border-radius: 12px;
-    background: rgba(8, 12, 18, .96);
+    aspect-ratio: 16 / 9;
+    border-radius: 14px;
+    background: rgba(3, 6, 12, 1);
+}
+
+.go-live-preview-stage::after {
+    content: "";
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    width: 10px;
+    height: 10px;
+    border-radius: 999px;
+    background: #ff5c5c;
+    box-shadow: 0 0 10px rgba(255, 92, 92, .45);
 }
 
 .go-live-preview-video {
     width: 100%;
     height: 100%;
-    min-height: 112px;
     object-fit: cover;
     display: block;
-    background: rgba(10, 14, 20, .4);
+    background: rgba(3, 6, 12, 1);
 }
 
 .go-live-preview-empty {
-    min-height: 112px;
+    min-height: 160px;
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -49,19 +58,19 @@
 }
 
 .go-live-preview-footer .set-account-name {
-    color: rgba(255, 245, 224, .88);
-    font-size: 12px;
+    color: rgba(255, 245, 224, .9);
+    font-size: 13px;
 }
 
 .go-live-preview-switch {
-    min-height: 24px;
-    padding: 0 10px;
-    border: 1px solid rgba(214, 166, 91, .12);
-    border-radius: 999px;
-    background: rgba(255, 255, 255, .02);
-    color: rgba(248, 241, 226, .74);
+    min-height: 30px;
+    padding: 0 12px;
+    border: 1px solid rgba(16, 185, 129, .22);
+    border-radius: 10px;
+    background: rgba(16, 185, 129, .12);
+    color: #59d8a7;
     font-size: 10px;
-    font-weight: 700;
+    font-weight: 800;
     letter-spacing: .08em;
     text-transform: uppercase;
 }

--- a/src/PrompterLive.Shared/GoLive/Components/GoLiveProgramFeedCard.razor
+++ b/src/PrompterLive.Shared/GoLive/Components/GoLiveProgramFeedCard.razor
@@ -1,15 +1,14 @@
 @namespace PrompterLive.Shared.Components.GoLive
 @using PrompterLive.Core.Models.Media
-@using PrompterLive.Core.Models.Workspace
 
 <section class="go-live-stage-shell"
          data-live-state="@LiveState"
          data-testid="@UiTestIds.GoLive.ProgramCard">
     <div class="go-live-stage-header">
         <div>
-            <span class="go-live-sidebar-title">@Title</span>
+            <span class="go-live-monitor-label">@Title</span>
             <h2 class="go-live-stage-title"
-                data-testid="@UiTestIds.GoLive.Stage">@ActiveSourceLabel</h2>
+                data-testid="@UiTestIds.GoLive.Stage">@SelectedSourceLabel</h2>
         </div>
 
         <span class="live-status @(IsArmed ? ReadyCssClass : PendingCssClass)">@ActiveSessionLabel</span>
@@ -22,9 +21,12 @@
                          VideoDomId="@UiDomIds.GoLive.ProgramVideo"
                          VideoTestId="@UiTestIds.GoLive.ProgramVideo">
         <OverlayContent>
-            <div class="go-live-stage-footer">
-                <span>@EffectiveProgramResolutionLabel</span>
-                <span>@EffectiveStageFrameRateLabel</span>
+            <div class="go-live-stage-overlay">
+                <span class="go-live-stage-chip">@SelectedLabel</span>
+                <div class="go-live-stage-footer">
+                    <span>@ProgramResolutionLabel</span>
+                    <span>@StageFrameRateLabel</span>
+                </div>
             </div>
         </OverlayContent>
         <EmptyContent>
@@ -38,72 +40,39 @@
 
     <div class="go-live-stage-meta">
         <article class="go-live-stage-meta-card">
-            <span class="set-section-label">Selected</span>
-            <strong data-testid="@UiTestIds.GoLive.SelectedSourceLabel">@SelectedSourceLabel</strong>
+            <span class="set-section-label">@LiveLabel</span>
+            <strong data-testid="@UiTestIds.GoLive.ActiveSourceLabel">@ActiveSourceLabel</strong>
         </article>
         <article class="go-live-stage-meta-card">
-            <span class="set-section-label">Program</span>
-            <strong data-testid="@UiTestIds.GoLive.ActiveSourceLabel">@ActiveSourceLabel</strong>
+            <span class="set-section-label">@CanvasLabel</span>
+            <strong data-testid="@UiTestIds.GoLive.SelectedSourceLabel">@SelectedSourceLabel</strong>
         </article>
     </div>
 </section>
 
-@ActionContent
-@PreviewContent
-@ChildContent
-
 @code {
-    private const string DefaultTitle = "Program";
+    private const string CanvasLabel = "Canvas";
+    private const string DefaultTitle = "Canvas";
     private const string IdleStateCss = "idle";
-    private const string NoCameraDescription = "Add or include a camera in Settings to send a live program feed.";
-    private const string NoCameraTitle = "No program camera";
+    private const string LiveLabel = "On Air";
+    private const string NoCameraDescription = "Select or add a camera source to build the live canvas.";
+    private const string NoCameraTitle = "No canvas source";
     private const string PendingCssClass = "pending";
     private const string ReadyCssClass = "ready";
     private const string RecordingStateCss = "recording";
+    private const string SelectedLabel = "Selected";
     private const string StreamingStateCss = "streaming";
 
     [Parameter] public string ActiveSessionLabel { get; set; } = string.Empty;
     [Parameter] public string ActiveSourceLabel { get; set; } = string.Empty;
-    [Parameter] public RenderFragment? ActionContent { get; set; }
-    [Parameter] public string AudioTelemetry { get; set; } = string.Empty;
-    [Parameter] public int BitrateKbps { get; set; }
-    [Parameter] public EventCallback<ChangeEventArgs> BitrateChanged { get; set; }
-    [Parameter] public string BitrateTelemetry { get; set; } = string.Empty;
-    [Parameter] public bool CanControlProgram { get; set; }
     [Parameter] public SceneCameraSource? Camera { get; set; }
-    [Parameter] public RenderFragment? ChildContent { get; set; }
-    [Parameter] public bool IncludeCameraInOutput { get; set; }
     [Parameter] public bool IsArmed { get; set; }
     [Parameter] public bool IsRecordingActive { get; set; }
     [Parameter] public bool IsStreamActive { get; set; }
-    [Parameter] public string OutputDestinationsTelemetry { get; set; } = string.Empty;
-    [Parameter] public StreamingResolutionPreset OutputResolution { get; set; }
-    [Parameter] public EventCallback<ChangeEventArgs> OutputResolutionChanged { get; set; }
     [Parameter] public string ProgramResolutionLabel { get; set; } = string.Empty;
-    [Parameter] public RenderFragment? PreviewContent { get; set; }
-    [Parameter] public string RecordingActionLabel { get; set; } = string.Empty;
-    [Parameter] public bool ShowTextOverlay { get; set; }
     [Parameter] public string SelectedSourceLabel { get; set; } = string.Empty;
     [Parameter] public string StageFrameRateLabel { get; set; } = string.Empty;
-    [Parameter] public EventCallback SwitchSelectedSource { get; set; }
-    [Parameter] public string SwitchActionLabel { get; set; } = string.Empty;
-    [Parameter] public string StreamActionLabel { get; set; } = string.Empty;
-    [Parameter] public EventCallback ToggleIncludeCamera { get; set; }
-    [Parameter] public EventCallback ToggleRecordingSession { get; set; }
-    [Parameter] public EventCallback ToggleStreamSession { get; set; }
-    [Parameter] public EventCallback ToggleTextOverlay { get; set; }
     [Parameter] public string Title { get; set; } = DefaultTitle;
-    [Parameter] public string VideoTelemetry { get; set; } = string.Empty;
-
-    private string EffectiveProgramResolutionLabel =>
-        string.IsNullOrWhiteSpace(ProgramResolutionLabel)
-            ? OutputResolution.ToString()
-            : ProgramResolutionLabel;
-
-    private string EffectiveStageFrameRateLabel =>
-        string.IsNullOrWhiteSpace(StageFrameRateLabel)
-            ? BitrateTelemetry
-            : StageFrameRateLabel;
 
     private string LiveState => IsRecordingActive
         ? RecordingStateCss

--- a/src/PrompterLive.Shared/GoLive/Components/GoLiveProgramFeedCard.razor.css
+++ b/src/PrompterLive.Shared/GoLive/Components/GoLiveProgramFeedCard.razor.css
@@ -1,14 +1,9 @@
 .go-live-stage-shell {
     display: flex;
     flex-direction: column;
-    gap: 16px;
+    gap: 12px;
     min-width: 0;
-    height: 100%;
-    padding: 10px;
-    border: 1px solid rgba(214, 166, 91, .12);
-    border-radius: 22px;
-    background: rgba(6, 9, 18, .82);
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, .04);
+    min-height: 0;
 }
 
 .go-live-stage-header {
@@ -16,57 +11,94 @@
     align-items: flex-start;
     justify-content: space-between;
     gap: 16px;
-    padding: 6px 8px 0;
+}
+
+.go-live-monitor-label {
+    display: inline-flex;
+    align-items: center;
+    min-height: 24px;
+    padding: 0 10px;
+    border-radius: 999px;
+    border: 1px solid rgba(96, 165, 250, .2);
+    background: rgba(96, 165, 250, .08);
+    color: #8ebcf8;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: .14em;
+    text-transform: uppercase;
 }
 
 .go-live-stage-title {
-    margin: 6px 0 0;
+    margin: 8px 0 0;
     color: rgba(255, 245, 224, .96);
-    font-size: 15px;
+    font-size: 20px;
     font-weight: 700;
-    letter-spacing: .02em;
+    letter-spacing: -.02em;
 }
 
 .go-live-stage-viewport {
     position: relative;
     overflow: hidden;
-    min-height: 640px;
-    border: 1px solid rgba(214, 166, 91, .08);
-    border-radius: 18px;
-    background: rgba(8, 12, 18, .96);
+    flex: 1;
+    min-height: 520px;
+    border: 1px solid rgba(255, 255, 255, .08);
+    border-radius: 22px;
+    background:
+        radial-gradient(circle at center, rgba(255, 255, 255, .03), transparent 55%),
+        rgba(3, 6, 12, 1);
 }
 
 .go-live-stage-video {
     width: 100%;
     height: 100%;
-    min-height: 640px;
+    min-height: 520px;
     object-fit: cover;
     display: block;
-    background: rgba(8, 12, 18, .96);
+    background: rgba(3, 6, 12, 1);
+}
+
+.go-live-stage-overlay {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    padding: 16px;
+    pointer-events: none;
+}
+
+.go-live-stage-chip {
+    align-self: flex-start;
+    display: inline-flex;
+    align-items: center;
+    min-height: 24px;
+    padding: 0 10px;
+    border-radius: 999px;
+    border: 1px solid rgba(196, 160, 96, .24);
+    background: rgba(196, 160, 96, .12);
+    color: rgba(255, 245, 224, .92);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: .12em;
+    text-transform: uppercase;
 }
 
 .go-live-stage-empty {
-    min-height: 640px;
+    min-height: 520px;
     display: flex;
     flex-direction: column;
     justify-content: center;
 }
 
 .go-live-stage-footer {
-    position: absolute;
-    right: 16px;
-    bottom: 12px;
-    left: 16px;
     display: flex;
     align-items: center;
     justify-content: space-between;
     gap: 12px;
-    color: rgba(248, 241, 226, .34);
-    font-size: 10px;
+    color: rgba(248, 241, 226, .5);
+    font-size: 11px;
     letter-spacing: .08em;
     text-transform: uppercase;
-    z-index: 1;
-    pointer-events: none;
 }
 
 .go-live-stage-meta {
@@ -81,9 +113,9 @@
     gap: 6px;
     min-width: 0;
     padding: 14px 16px;
-    border: 1px solid rgba(214, 166, 91, .08);
+    border: 1px solid rgba(255, 255, 255, .06);
     border-radius: 16px;
-    background: rgba(255, 255, 255, .02);
+    background: rgba(8, 11, 18, .78);
 }
 
 .go-live-stage-meta-card strong {
@@ -92,31 +124,32 @@
     line-height: 1.35;
 }
 
-.go-live-stage-shell[data-live-state="recording"] {
-    border-color: rgba(255, 120, 120, .22);
+.go-live-stage-shell[data-live-state="recording"] .go-live-stage-viewport {
+    border-color: rgba(255, 107, 107, .28);
 }
 
-@media (max-width: 1200px) {
+.go-live-stage-shell[data-live-state="streaming"] .go-live-stage-viewport {
+    border-color: rgba(16, 185, 129, .26);
+}
+
+@media (max-width: 1120px) {
     .go-live-stage-viewport,
     .go-live-stage-video,
     .go-live-stage-empty {
-        min-height: 520px;
+        min-height: 440px;
     }
 }
 
 @media (max-width: 720px) {
-    .go-live-stage-meta {
-        grid-template-columns: 1fr;
-    }
-
-    .go-live-stage-viewport,
-    .go-live-stage-video,
-    .go-live-stage-empty {
-        min-height: 380px;
-    }
-
     .go-live-stage-header {
         flex-direction: column;
-        align-items: stretch;
+    }
+
+    .go-live-stage-title {
+        font-size: 17px;
+    }
+
+    .go-live-stage-meta {
+        grid-template-columns: 1fr;
     }
 }

--- a/src/PrompterLive.Shared/GoLive/Components/GoLiveSceneControls.razor.css
+++ b/src/PrompterLive.Shared/GoLive/Components/GoLiveSceneControls.razor.css
@@ -3,9 +3,9 @@
     flex-direction: column;
     gap: 12px;
     padding: 12px;
-    border: 1px solid rgba(214, 166, 91, .08);
+    border: 1px solid rgba(255, 255, 255, .06);
     border-radius: 18px;
-    background: rgba(6, 9, 18, .88);
+    background: rgba(8, 11, 18, .78);
 }
 
 .go-live-scenes-bar,
@@ -34,23 +34,23 @@
     align-items: center;
     justify-content: center;
     gap: 8px;
-    min-height: 34px;
+    min-height: 36px;
     padding: 0 12px;
-    border: 1px solid rgba(214, 166, 91, .1);
-    border-radius: 10px;
-    background: rgba(255, 255, 255, .02);
+    border: 1px solid rgba(255, 255, 255, .08);
+    border-radius: 12px;
+    background: rgba(255, 255, 255, .03);
     color: rgba(248, 241, 226, .72);
     font-size: 11px;
     font-weight: 700;
-    letter-spacing: .05em;
+    letter-spacing: .06em;
     text-transform: uppercase;
 }
 
 .go-live-scene-chip.active,
 .go-live-toolbar-button.active {
+    border-color: rgba(196, 160, 96, .28);
+    background: rgba(196, 160, 96, .14);
     color: rgba(255, 245, 224, .96);
-    border-color: rgba(214, 166, 91, .24);
-    background: rgba(111, 43, 20, .3);
 }
 
 .go-live-scene-chip-name {
@@ -58,15 +58,10 @@
     letter-spacing: 0;
 }
 
-.go-live-scene-chip-icon {
-    color: #f4d9b0;
-    font-size: 12px;
-}
-
 .go-live-scene-add {
-    min-width: 34px;
+    min-width: 36px;
     padding: 0;
-    font-size: 16px;
+    font-size: 18px;
 }
 
 .go-live-scene-toolbar {
@@ -88,12 +83,12 @@
 }
 
 .go-live-take-to-air {
-    color: #7ff3bf;
-    border-color: rgba(127, 243, 191, .18);
-    background: rgba(11, 60, 48, .28);
+    border-color: rgba(16, 185, 129, .26);
+    background: rgba(16, 185, 129, .12);
+    color: #59d8a7;
 }
 
-@media (max-width: 1200px) {
+@media (max-width: 960px) {
     .go-live-scene-toolbar {
         flex-direction: column;
         align-items: stretch;

--- a/src/PrompterLive.Shared/GoLive/Components/GoLiveSourcesCard.razor
+++ b/src/PrompterLive.Shared/GoLive/Components/GoLiveSourcesCard.razor
@@ -4,9 +4,14 @@
 <section class="go-live-sources-shell"
          data-testid="@UiTestIds.GoLive.SourceRail">
     <div class="go-live-sidebar-header">
-        <span class="go-live-sidebar-title">Inputs</span>
-        <a class="go-live-sidebar-action"
-           href="@SettingsRoute">+</a>
+        <span class="go-live-sidebar-title">@Title</span>
+        <div class="go-live-sources-actions">
+            <button type="button"
+                    class="go-live-sidebar-action"
+                    disabled="@(!CanAddCamera)"
+                    data-testid="@UiTestIds.GoLive.AddSource"
+                    @onclick="AddCamera">+</button>
+        </div>
     </div>
 
     <div class="go-live-sources-stack"
@@ -20,13 +25,13 @@
             @foreach (var source in Sources)
             {
                 <article class="go-live-source-tile"
+                         data-active="@IsActive(source)"
+                         data-selected="@IsSelected(source)"
                          data-testid="@UiTestIds.GoLive.SourceCamera(source.SourceId)">
                     <button type="button"
                             class="go-live-source-select"
-                            data-active="@IsActive(source)"
-                            data-selected="@IsSelected(source)"
-                            @onclick="() => SelectSource.InvokeAsync(source.SourceId)"
-                            data-testid="@UiTestIds.GoLive.SourceCameraSelect(source.SourceId)">
+                            data-testid="@UiTestIds.GoLive.SourceCameraSelect(source.SourceId)"
+                            @onclick="() => SelectSource.InvokeAsync(source.SourceId)">
                         <GoLiveCameraSurface Camera="@source"
                                              ContainerClass="go-live-source-video-shell"
                                              VideoClass="go-live-source-video"
@@ -35,6 +40,7 @@
                                 <span class="go-live-source-badge">@GetSourceBadge(source)</span>
                             </OverlayContent>
                         </GoLiveCameraSurface>
+
                         <span class="go-live-source-copy">
                             <strong>@source.Label</strong>
                             <span>@GetSourceStatus(source)</span>
@@ -81,41 +87,23 @@
         }
     </div>
 
-    <div class="go-live-participants-shell">
-        <div class="go-live-sidebar-header go-live-participants-header">
-            <span class="go-live-sidebar-title">Participants</span>
-            <span class="go-live-participants-icon">+</span>
-        </div>
-
-        <article class="go-live-participant-card">
-            <div>
-                <strong>@HostLabel</strong>
-                <span>@ParticipantRoleLabel</span>
-            </div>
-            <span class="go-live-participant-badge">@DirectorLabel</span>
-        </article>
-
-        <div class="go-live-participant-actions">
-            <a class="go-live-source-action"
-               href="@SettingsRoute">@InviteLabel</a>
-        </div>
+    <div class="go-live-mic-card">
+        <span class="go-live-sidebar-title">@MicrophoneTitle</span>
+        <strong>@MicrophoneName</strong>
+        <span>@MicrophoneRouteLabel</span>
     </div>
 </section>
 
 @code {
-    private const string AddLabel = "Add To Live Feed";
-    private const string DefaultDescription = "Pick the camera that should be ready for the next switch, while keeping inclusion controls nearby.";
-    private const string DefaultTitle = "Live Cameras";
-    private const string DirectorLabel = "Director";
+    private const string AddLabel = "Include";
+    private const string DefaultTitle = "Inputs";
     private const string EmptyStateMessage = "No scene cameras are configured yet. Add them in Settings first.";
-    private const string HostLabel = "You (Host)";
-    private const string InviteLabel = "Invite to session";
-    private const string ParticipantRoleLabel = "Primary control room";
-    private const string RemoveLabel = "Remove From Live Feed";
+    private const string MicrophoneTitle = "Microphone";
+    private const string RemoveLabel = "Remove";
     private const string ScriptProgressDefaultLabel = "No script loaded";
-    private const string SourceIncludedLabel = "Included in program output";
-    private const string SourceLiveLabel = "Ready for live switch";
-    private const string SourceOnAirLabel = "On Air";
+    private const string SourceIncludedLabel = "Armed for output";
+    private const string SourceLiveLabel = "Ready for canvas";
+    private const string SourceOnAirLabel = "On air";
     private const string SourceSceneOnlyLabel = "Scene only";
     private static readonly IReadOnlyList<GoLiveCropPreset> CropOptions =
     [
@@ -126,16 +114,16 @@
 
     private readonly Dictionary<string, GoLiveCropPreset> _cropSelections = new(StringComparer.Ordinal);
 
+    [Parameter] public EventCallback AddCamera { get; set; }
     [Parameter] public string? ActiveSourceId { get; set; }
+    [Parameter] public bool CanAddCamera { get; set; }
     [Parameter] public string CurrentScriptProgressLabel { get; set; } = ScriptProgressDefaultLabel;
     [Parameter] public string CurrentScriptTitle { get; set; } = ScriptWorkspaceState.UntitledScriptTitle;
-    [Parameter] public string Description { get; set; } = DefaultDescription;
     [Parameter] public bool HasPrimaryMicrophone { get; set; }
     [Parameter] public string MicrophoneName { get; set; } = string.Empty;
     [Parameter] public string MicrophoneRouteLabel { get; set; } = string.Empty;
     [Parameter] public EventCallback<string> SelectSource { get; set; }
     [Parameter] public string? SelectedSourceId { get; set; }
-    [Parameter] public string SettingsRoute { get; set; } = AppRoutes.Settings;
     [Parameter] public IReadOnlyList<SceneCameraSource> Sources { get; set; } = [];
     [Parameter] public string Title { get; set; } = DefaultTitle;
     [Parameter] public EventCallback<string> ToggleSource { get; set; }
@@ -174,7 +162,11 @@
             return SourceOnAirLabel;
         }
 
-        return source.Transform.IncludeInOutput ? SourceIncludedLabel : SourceSceneOnlyLabel;
+        return IsSelected(source)
+            ? SourceLiveLabel
+            : source.Transform.IncludeInOutput
+                ? SourceIncludedLabel
+                : SourceSceneOnlyLabel;
     }
 
     private GoLiveCropPreset GetCropSelection(string sourceId)

--- a/src/PrompterLive.Shared/GoLive/Components/GoLiveSourcesCard.razor.css
+++ b/src/PrompterLive.Shared/GoLive/Components/GoLiveSourcesCard.razor.css
@@ -4,19 +4,14 @@
 .go-live-source-copy,
 .go-live-utility-stack,
 .go-live-utility-copy,
-.go-live-participants-shell,
-.go-live-participant-actions {
+.go-live-mic-card {
     display: flex;
     flex-direction: column;
 }
 
 .go-live-sources-shell {
-    gap: 16px;
+    gap: 12px;
     height: 100%;
-    padding: 10px;
-    border: 1px solid rgba(214, 166, 91, .08);
-    border-radius: 22px;
-    background: rgba(6, 9, 18, .88);
 }
 
 .go-live-sidebar-header {
@@ -24,60 +19,78 @@
     align-items: center;
     justify-content: space-between;
     gap: 12px;
-    padding: 4px 2px 0;
 }
 
 .go-live-sidebar-title {
-    color: rgba(248, 241, 226, .36);
+    color: rgba(248, 241, 226, .34);
     font-size: 10px;
     font-weight: 700;
     letter-spacing: .16em;
     text-transform: uppercase;
 }
 
+.go-live-sources-actions {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
 .go-live-sidebar-action,
-.go-live-participants-icon,
 .go-live-source-crop,
 .go-live-source-action,
 .go-live-utility-badge {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    border: 1px solid rgba(214, 166, 91, .14);
-    border-radius: 8px;
-    color: rgba(248, 241, 226, .72);
+    border: 1px solid rgba(255, 255, 255, .08);
+    border-radius: 10px;
+    background: rgba(255, 255, 255, .03);
+    color: rgba(248, 241, 226, .74);
 }
 
-.go-live-sidebar-action,
-.go-live-participants-icon {
-    width: 18px;
-    height: 18px;
+.go-live-sidebar-action {
+    width: 28px;
+    height: 28px;
+    padding: 0;
     text-decoration: none;
-    font-size: 12px;
+    font-size: 14px;
     font-weight: 700;
 }
 
-.go-live-sources-stack,
-.go-live-utility-stack,
-.go-live-participants-shell,
-.go-live-participant-actions {
-    gap: 10px;
+.go-live-sidebar-action:disabled {
+    opacity: .35;
+}
+
+.go-live-sources-stack {
+    gap: 8px;
+    min-height: 0;
+    overflow-y: auto;
+    padding-right: 4px;
 }
 
 .go-live-source-tile,
 .go-live-utility-tile,
-.go-live-participant-card {
+.go-live-mic-card {
     gap: 8px;
-    padding: 10px;
-    border: 1px solid rgba(214, 166, 91, .06);
+    padding: 8px;
+    border: 1px solid rgba(255, 255, 255, .06);
     border-radius: 14px;
-    background: rgba(255, 255, 255, .02);
+    background: rgba(8, 11, 18, .76);
+}
+
+.go-live-source-tile[data-active="True"] {
+    border-color: rgba(255, 107, 107, .32);
+    background: rgba(255, 68, 68, .08);
+}
+
+.go-live-source-tile[data-selected="True"] {
+    border-color: rgba(196, 160, 96, .3);
+    background: rgba(196, 160, 96, .08);
 }
 
 .go-live-source-select {
     display: grid;
-    grid-template-columns: 1fr;
-    gap: 10px;
+    gap: 8px;
     padding: 0;
     border: none;
     background: transparent;
@@ -88,53 +101,47 @@
 .go-live-source-video-shell {
     position: relative;
     overflow: hidden;
-    min-height: 90px;
-    border-radius: 10px;
-    border: 1px solid rgba(255, 255, 255, .04);
-    background: rgba(8, 12, 18, .96);
+    aspect-ratio: 16 / 9;
+    border-radius: 12px;
+    background: rgba(2, 5, 10, 1);
 }
 
 .go-live-source-video {
     width: 100%;
-    height: 90px;
+    height: 100%;
     object-fit: cover;
     display: block;
-    background: rgba(8, 12, 18, .96);
+    background: rgba(2, 5, 10, 1);
 }
 
-.go-live-source-badge,
-.go-live-utility-badge,
-.go-live-participant-badge {
+.go-live-source-badge {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    display: inline-flex;
+    align-items: center;
     min-height: 22px;
     padding: 0 8px;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, .1);
+    background: rgba(6, 10, 18, .72);
+    color: rgba(255, 245, 224, .88);
     font-size: 9px;
     font-weight: 700;
     letter-spacing: .08em;
     text-transform: uppercase;
 }
 
-.go-live-source-badge {
-    position: absolute;
-    top: 10px;
-    right: 10px;
-    display: inline-flex;
-    align-items: center;
-    padding: 0 8px;
-    border: 1px solid rgba(127, 243, 191, .18);
-    border-radius: 999px;
-    background: rgba(11, 60, 48, .28);
-    color: #7ff3bf;
-}
-
 .go-live-source-copy,
-.go-live-utility-copy {
+.go-live-utility-copy,
+.go-live-mic-card {
     gap: 2px;
 }
 
 .go-live-source-copy strong,
 .go-live-utility-copy strong,
-.go-live-participant-card strong {
-    color: rgba(255, 245, 224, .9);
+.go-live-mic-card strong {
+    color: rgba(255, 245, 224, .92);
     font-size: 12px;
     line-height: 1.3;
 }
@@ -142,20 +149,16 @@
 .go-live-source-copy span,
 .go-live-utility-copy span,
 .go-live-source-script span,
-.go-live-participant-card span {
-    color: rgba(248, 241, 226, .34);
+.go-live-mic-card span {
+    color: rgba(248, 241, 226, .4);
     font-size: 10px;
     line-height: 1.35;
 }
 
-.go-live-source-select[data-selected="True"] .go-live-source-copy strong {
-    color: #f4dfb7;
-}
-
 .go-live-source-crops {
     display: flex;
-    flex-wrap: wrap;
     gap: 6px;
+    flex-wrap: wrap;
 }
 
 .go-live-source-crop,
@@ -163,7 +166,6 @@
 .go-live-utility-badge {
     min-height: 28px;
     padding: 0 10px;
-    background: rgba(255, 255, 255, .02);
     font-size: 10px;
     font-weight: 700;
     letter-spacing: .08em;
@@ -171,52 +173,40 @@
 }
 
 .go-live-source-crop.active {
+    border-color: rgba(196, 160, 96, .28);
+    background: rgba(196, 160, 96, .14);
     color: rgba(255, 245, 224, .96);
-    border-color: rgba(214, 166, 91, .24);
-    background: rgba(111, 43, 20, .3);
 }
 
 .go-live-source-script {
-    display: grid;
+    display: flex;
+    flex-direction: column;
     gap: 4px;
-    padding: 10px;
-    border: 1px solid rgba(214, 166, 91, .06);
+    padding: 8px 10px;
     border-radius: 12px;
-    background: rgba(255, 255, 255, .015);
+    background: rgba(255, 255, 255, .03);
 }
 
 .go-live-source-script strong {
-    color: rgba(255, 245, 224, .84);
+    color: rgba(255, 245, 224, .88);
     font-size: 11px;
 }
 
-.go-live-utility-tile,
-.go-live-participant-card {
+.go-live-utility-stack {
+    gap: 8px;
+}
+
+.go-live-utility-tile {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 12px;
+    gap: 10px;
 }
 
 .go-live-utility-badge {
     color: #f4d9b0;
 }
 
-.go-live-participants-shell {
+.go-live-mic-card {
     margin-top: auto;
-}
-
-.go-live-participant-card span {
-    display: block;
-}
-
-.go-live-participant-badge {
-    color: #7ff3bf;
-    border: 1px solid rgba(214, 166, 91, .1);
-    border-radius: 999px;
-}
-
-.go-live-participant-actions > a {
-    justify-content: center;
-    text-decoration: none;
 }

--- a/src/PrompterLive.Shared/GoLive/Components/GoLiveStudioModels.cs
+++ b/src/PrompterLive.Shared/GoLive/Components/GoLiveStudioModels.cs
@@ -60,7 +60,11 @@ public sealed record GoLiveDestinationSummaryViewModel(
     string Id,
     string Name,
     string PlatformLabel,
-    bool IsEnabled);
+    bool IsEnabled,
+    bool IsReady,
+    string Summary,
+    string StatusLabel,
+    string Tone);
 
 public sealed record GoLiveMetricViewModel(
     string Value,

--- a/src/PrompterLive.Shared/GoLive/Components/GoLiveStudioSidebar.razor
+++ b/src/PrompterLive.Shared/GoLive/Components/GoLiveStudioSidebar.razor
@@ -21,28 +21,39 @@
     {
         <div class="go-live-sidebar-panel">
             <div class="go-live-sidebar-section">
-                <span class="go-live-sidebar-label">Destinations</span>
+                <div class="go-live-sidebar-section-header">
+                    <span class="go-live-sidebar-label">@DestinationsLabel</span>
+                    <a class="go-live-sidebar-link" href="@SettingsRoute">Settings</a>
+                </div>
                 <div class="go-live-destination-list">
                     @foreach (var destination in Destinations)
                     {
-                        <button type="button"
-                                class="go-live-destination-row"
-                                @onclick="() => ToggleDestination.InvokeAsync(destination.Id)">
-                            <span class="go-live-destination-dot @GetDestinationTone(destination.Id)"></span>
-                            <span class="go-live-destination-copy">
-                                <strong>@destination.Name</strong>
-                                <span>@destination.PlatformLabel</span>
-                            </span>
-                            <span class="go-live-destination-toggle @(destination.IsEnabled ? "on" : null)">
-                                <span></span>
-                            </span>
-                        </button>
+                        <article class="go-live-destination-card"
+                                 data-testid="@UiTestIds.GoLive.ProviderCard(destination.Id)">
+                            <button type="button"
+                                    class="go-live-destination-row @(destination.IsEnabled ? "on" : null)"
+                                    data-testid="@GetToggleTestId(destination.Id)"
+                                    @onclick="() => ToggleDestination.InvokeAsync(destination.Id)">
+                                <span class="go-live-destination-dot @destination.Tone"></span>
+                                <span class="go-live-destination-copy">
+                                    <strong>@destination.Name</strong>
+                                    <span>@destination.PlatformLabel</span>
+                                </span>
+                                <span class="go-live-destination-toggle @(destination.IsEnabled ? "on" : null)">
+                                    <span></span>
+                                </span>
+                            </button>
+                            <div class="go-live-destination-meta">
+                                <span>@destination.Summary</span>
+                                <strong>@destination.StatusLabel</strong>
+                            </div>
+                        </article>
                     }
                 </div>
             </div>
 
             <div class="go-live-sidebar-section">
-                <span class="go-live-sidebar-label">Status</span>
+                <span class="go-live-sidebar-label">@StatusLabel</span>
                 <div class="go-live-sidebar-metrics">
                     @foreach (var metric in StatusMetrics)
                     {
@@ -55,7 +66,7 @@
             </div>
 
             <div class="go-live-sidebar-section">
-                <span class="go-live-sidebar-label">Runtime</span>
+                <span class="go-live-sidebar-label">@RuntimeLabel</span>
                 <div class="go-live-sidebar-metrics">
                     @foreach (var metric in RuntimeMetrics)
                     {
@@ -94,12 +105,12 @@
             {
                 <div class="go-live-room-empty"
                      data-testid="@UiTestIds.GoLive.RoomEmpty">
-                    <strong>Remote Room</strong>
-                    <p>Invite remote guests to send their camera, mic, or screen. You control everything from here.</p>
+                    <strong>@RoomTitle</strong>
+                    <p>@RoomDescription</p>
                     <button type="button"
                             class="go-live-room-create"
                             data-testid="@UiTestIds.GoLive.CreateRoom"
-                            @onclick="CreateRoom">Create Room</button>
+                            @onclick="CreateRoom">@CreateRoomLabel</button>
                 </div>
             }
             else
@@ -110,19 +121,19 @@
                         <span class="go-live-room-code">@RoomCode</span>
                         <button type="button"
                                 class="go-live-room-invite"
-                                data-testid="@UiTestIds.GoLive.RoomInvite">Invite</button>
+                                data-testid="@UiTestIds.GoLive.RoomInvite">@InviteLabel</button>
                     </div>
 
                     <div class="go-live-room-toolbar">
                         <button type="button"
                                 class="go-live-room-action @(_muteAllGuests ? "active" : null)"
-                                @onclick="ToggleMuteAllGuests">Mute All</button>
+                                @onclick="ToggleMuteAllGuests">@MuteAllLabel</button>
                         <button type="button"
                                 class="go-live-room-action @(_talkbackEnabled ? "active" : null)"
-                                @onclick="ToggleTalkback">Talk</button>
+                                @onclick="ToggleTalkback">@TalkLabel</button>
                         <button type="button"
                                 class="go-live-room-action @(_cueArmed ? "active cue" : null)"
-                                @onclick="SendCue">Cue</button>
+                                @onclick="SendCue">@CueLabel</button>
                     </div>
 
                     <div class="go-live-room-participants">
@@ -149,52 +160,46 @@
 </section>
 
 @code {
+    private const string CreateRoomLabel = "Create Room";
+    private const string CueLabel = "Cue";
+    private const string DestinationsLabel = "Destinations";
+    private const string InviteLabel = "Invite";
+    private const string MuteAllLabel = "Mute All";
+    private const string RoomDescription = "Invite remote guests to send their camera, mic, or screen. You control everything from here.";
+    private const string RoomTitle = "Remote Room";
+    private const string RuntimeLabel = "Runtime";
+    private const string StatusLabel = "Status";
+    private const string TalkLabel = "Talk";
+
     [Parameter] public GoLiveStudioTab ActiveTab { get; set; }
-
     [Parameter] public IReadOnlyList<GoLiveAudioChannelViewModel> AudioChannels { get; set; } = [];
-
     [Parameter] public EventCallback CreateRoom { get; set; }
-
     [Parameter] public bool CueArmed { get; set; }
-
     [Parameter] public IReadOnlyList<GoLiveDestinationSummaryViewModel> Destinations { get; set; } = [];
-
     [Parameter] public bool IsRoomActive { get; set; }
-
     [Parameter] public bool MuteAllGuests { get; set; }
-
     [Parameter] public IReadOnlyList<GoLiveRoomParticipantViewModel> Participants { get; set; } = [];
-
     [Parameter] public string RoomCode { get; set; } = string.Empty;
-
-    [Parameter] public EventCallback<GoLiveStudioTab> SelectTab { get; set; }
-
-    [Parameter] public EventCallback SendCue { get; set; }
-
     [Parameter] public IReadOnlyList<GoLiveMetricViewModel> RuntimeMetrics { get; set; } = [];
-
+    [Parameter] public EventCallback<GoLiveStudioTab> SelectTab { get; set; }
+    [Parameter] public EventCallback SendCue { get; set; }
+    [Parameter] public string SettingsRoute { get; set; } = AppRoutes.Settings;
     [Parameter] public IReadOnlyList<GoLiveMetricViewModel> StatusMetrics { get; set; } = [];
-
     [Parameter] public EventCallback<string> ToggleDestination { get; set; }
-
     [Parameter] public EventCallback ToggleMuteAllGuests { get; set; }
-
     [Parameter] public EventCallback ToggleTalkback { get; set; }
-
     [Parameter] public bool TalkbackEnabled { get; set; }
 
     private bool _cueArmed => CueArmed;
-
     private bool _muteAllGuests => MuteAllGuests;
-
     private bool _talkbackEnabled => TalkbackEnabled;
 
-    private static string GetDestinationTone(string targetId) =>
+    private static string GetToggleTestId(string targetId) =>
         targetId switch
         {
-            var id when string.Equals(id, GoLiveTargetCatalog.TargetIds.Twitch, StringComparison.Ordinal) => "twitch",
-            var id when string.Equals(id, GoLiveTargetCatalog.TargetIds.LiveKit, StringComparison.Ordinal) => "livekit",
-            var id when string.Equals(id, GoLiveTargetCatalog.TargetIds.CustomRtmp, StringComparison.Ordinal) => "custom",
-            _ => "youtube"
+            var id when string.Equals(id, GoLiveTargetCatalog.TargetIds.Obs, StringComparison.Ordinal) => UiTestIds.GoLive.ObsToggle,
+            var id when string.Equals(id, GoLiveTargetCatalog.TargetIds.Recording, StringComparison.Ordinal) => UiTestIds.GoLive.RecordingToggle,
+            var id when string.Equals(id, GoLiveTargetCatalog.TargetIds.LiveKit, StringComparison.Ordinal) => UiTestIds.GoLive.LiveKitToggle,
+            _ => UiTestIds.GoLive.YoutubeToggle
         };
 }

--- a/src/PrompterLive.Shared/GoLive/Components/GoLiveStudioSidebar.razor.css
+++ b/src/PrompterLive.Shared/GoLive/Components/GoLiveStudioSidebar.razor.css
@@ -2,7 +2,8 @@
 .go-live-sidebar-panel,
 .go-live-sidebar-section,
 .go-live-destination-copy,
-.go-live-room-copy {
+.go-live-room-copy,
+.go-live-audio-copy {
     display: flex;
     flex-direction: column;
 }
@@ -23,9 +24,9 @@
 .go-live-room-invite,
 .go-live-room-action,
 .go-live-destination-row {
-    border: 1px solid rgba(214, 166, 91, .1);
+    border: 1px solid rgba(255, 255, 255, .08);
     border-radius: 12px;
-    background: rgba(6, 9, 18, .88);
+    background: rgba(8, 11, 18, .78);
     color: rgba(248, 241, 226, .72);
 }
 
@@ -39,22 +40,36 @@
 
 .go-live-sidebar-tab.active,
 .go-live-room-action.active {
+    border-color: rgba(196, 160, 96, .28);
+    background: rgba(196, 160, 96, .14);
     color: rgba(255, 245, 224, .96);
-    border-color: rgba(214, 166, 91, .24);
-    background: rgba(111, 43, 20, .3);
 }
 
 .go-live-room-action.cue.active {
-    color: #7ff3bf;
-    border-color: rgba(127, 243, 191, .18);
-    background: rgba(11, 60, 48, .28);
+    border-color: rgba(16, 185, 129, .24);
+    background: rgba(16, 185, 129, .12);
+    color: #59d8a7;
 }
 
 .go-live-sidebar-panel {
     padding: 12px;
-    border: 1px solid rgba(214, 166, 91, .08);
+    border: 1px solid rgba(255, 255, 255, .06);
     border-radius: 18px;
-    background: rgba(6, 9, 18, .88);
+    background: rgba(8, 11, 18, .78);
+}
+
+.go-live-sidebar-section-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+}
+
+.go-live-sidebar-link {
+    color: #8ebcf8;
+    font-size: 11px;
+    font-weight: 700;
+    text-decoration: none;
 }
 
 .go-live-sidebar-label {
@@ -72,59 +87,90 @@
     gap: 10px;
 }
 
-.go-live-destination-row,
-.go-live-room-participant {
-    display: grid;
-    align-items: center;
-    gap: 10px;
+.go-live-destination-card {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 8px;
+    border: 1px solid rgba(255, 255, 255, .05);
+    border-radius: 14px;
+    background: rgba(255, 255, 255, .02);
 }
 
 .go-live-destination-row {
+    display: grid;
     grid-template-columns: auto minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 10px;
     padding: 10px 12px;
     text-align: left;
+}
+
+.go-live-destination-row.on {
+    border-color: rgba(16, 185, 129, .24);
 }
 
 .go-live-destination-dot {
     width: 10px;
     height: 10px;
     border-radius: 999px;
-    background: #ff4444;
+    background: #8b96a6;
 }
 
-.go-live-destination-dot.twitch {
-    background: #9146ff;
+.go-live-destination-dot.youtube {
+    background: #ff4444;
 }
 
 .go-live-destination-dot.livekit {
     background: #60a5fa;
 }
 
-.go-live-destination-dot.custom {
-    background: #c4a060;
+.go-live-destination-dot.local {
+    background: #8b96a6;
+}
+
+.go-live-destination-dot.recording {
+    background: #ff8d8d;
 }
 
 .go-live-destination-copy strong,
 .go-live-room-copy strong,
-.go-live-room-empty strong {
+.go-live-room-empty strong,
+.go-live-audio-copy strong {
     color: rgba(255, 245, 224, .92);
     font-size: 12px;
 }
 
 .go-live-destination-copy span,
+.go-live-destination-meta span,
 .go-live-room-copy span,
-.go-live-room-empty p {
-    color: rgba(248, 241, 226, .38);
+.go-live-room-empty p,
+.go-live-audio-copy span {
+    color: rgba(248, 241, 226, .4);
     font-size: 11px;
     line-height: 1.45;
 }
 
+.go-live-destination-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 0 4px;
+}
+
+.go-live-destination-meta strong {
+    color: rgba(255, 245, 224, .86);
+    font-size: 11px;
+    letter-spacing: .08em;
+    text-transform: uppercase;
+}
+
 .go-live-destination-toggle {
     position: relative;
-    width: 34px;
+    width: 36px;
     height: 20px;
     border-radius: 999px;
-    background: rgba(255, 255, 255, .08);
+    background: rgba(255, 255, 255, .12);
 }
 
 .go-live-destination-toggle > span {
@@ -134,17 +180,17 @@
     width: 16px;
     height: 16px;
     border-radius: 999px;
-    background: rgba(255, 245, 224, .8);
+    background: rgba(255, 245, 224, .82);
     transition: transform .18s ease;
 }
 
 .go-live-destination-toggle.on {
-    background: rgba(127, 243, 191, .2);
+    background: rgba(16, 185, 129, .24);
 }
 
 .go-live-destination-toggle.on > span {
-    transform: translateX(14px);
-    background: #7ff3bf;
+    transform: translateX(16px);
+    background: #59d8a7;
 }
 
 .go-live-sidebar-metrics {
@@ -156,9 +202,9 @@
 .go-live-sidebar-metrics div {
     display: grid;
     gap: 4px;
-    padding: 10px 12px;
-    border: 1px solid rgba(214, 166, 91, .08);
-    border-radius: 12px;
+    padding: 12px;
+    border: 1px solid rgba(255, 255, 255, .05);
+    border-radius: 14px;
     background: rgba(255, 255, 255, .02);
 }
 
@@ -176,19 +222,8 @@
 
 .go-live-audio-row {
     display: grid;
-    grid-template-columns: 64px minmax(0, 1fr);
-    gap: 12px;
-    align-items: center;
-}
-
-.go-live-audio-copy strong {
-    color: rgba(255, 245, 224, .9);
-    font-size: 12px;
-}
-
-.go-live-audio-copy span {
-    color: rgba(248, 241, 226, .34);
-    font-size: 10px;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 8px;
 }
 
 .go-live-audio-meter,
@@ -238,10 +273,10 @@
     align-items: center;
     min-height: 34px;
     padding: 0 12px;
-    border: 1px solid rgba(127, 243, 191, .18);
+    border: 1px solid rgba(16, 185, 129, .24);
     border-radius: 12px;
-    background: rgba(11, 60, 48, .28);
-    color: #7ff3bf;
+    background: rgba(16, 185, 129, .12);
+    color: #59d8a7;
     font-family: var(--font-mono);
     font-size: 12px;
     font-weight: 700;
@@ -249,9 +284,12 @@
 }
 
 .go-live-room-participant {
-    grid-template-columns: auto minmax(0, 1fr) minmax(0, 80px) auto;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) minmax(0, 88px) auto;
+    align-items: center;
+    gap: 10px;
     padding: 10px 12px;
-    border: 1px solid rgba(214, 166, 91, .08);
+    border: 1px solid rgba(255, 255, 255, .05);
     border-radius: 12px;
     background: rgba(255, 255, 255, .02);
 }
@@ -277,5 +315,11 @@
 }
 
 .go-live-room-dot.online {
-    background: #7ff3bf;
+    background: #59d8a7;
+}
+
+@media (max-width: 720px) {
+    .go-live-sidebar-metrics {
+        grid-template-columns: 1fr;
+    }
 }

--- a/src/PrompterLive.Shared/GoLive/Pages/GoLivePage.Actions.cs
+++ b/src/PrompterLive.Shared/GoLive/Pages/GoLivePage.Actions.cs
@@ -1,7 +1,27 @@
+using PrompterLive.Core.Models.Media;
+
 namespace PrompterLive.Shared.Pages;
 
 public partial class GoLivePage
 {
+    private async Task AddAvailableCameraAsync()
+    {
+        await EnsurePageReadyAsync();
+
+        var nextCamera = _mediaDevices.FirstOrDefault(device =>
+            device.Kind == MediaDeviceKind.Camera
+            && SceneCameras.All(camera => !string.Equals(camera.DeviceId, device.DeviceId, StringComparison.Ordinal)));
+
+        if (nextCamera is null)
+        {
+            return;
+        }
+
+        var source = MediaSceneService.AddCamera(nextCamera.DeviceId, nextCamera.Label);
+        GoLiveSession.SelectSource(SceneCameras, source.SourceId);
+        await PersistSceneAsync();
+    }
+
     private async Task ToggleSceneOutputAsync(string sourceId)
     {
         await EnsurePageReadyAsync();

--- a/src/PrompterLive.Shared/GoLive/Pages/GoLivePage.Bootstrap.cs
+++ b/src/PrompterLive.Shared/GoLive/Pages/GoLivePage.Bootstrap.cs
@@ -96,8 +96,17 @@ public partial class GoLivePage
             return;
         }
 
+        _mediaDevices = devices;
+        var cameraDevices = devices.Where(device => device.Kind == MediaDeviceKind.Camera).ToList();
         var microphoneDevices = devices.Where(device => device.Kind == MediaDeviceKind.Microphone).ToList();
         var changed = false;
+
+        if (SceneCameras.Count == 0 && cameraDevices.Count > 0)
+        {
+            var defaultCamera = cameraDevices.FirstOrDefault(device => device.IsDefault) ?? cameraDevices[0];
+            MediaSceneService.AddCamera(defaultCamera.DeviceId, defaultCamera.Label);
+            changed = true;
+        }
 
         if (string.IsNullOrWhiteSpace(MediaSceneService.State.PrimaryMicrophoneId) && microphoneDevices.Count > 0)
         {

--- a/src/PrompterLive.Shared/GoLive/Pages/GoLivePage.Destinations.cs
+++ b/src/PrompterLive.Shared/GoLive/Pages/GoLivePage.Destinations.cs
@@ -1,5 +1,4 @@
 using System.Globalization;
-using Microsoft.AspNetCore.Components;
 using PrompterLive.Core.Models.Workspace;
 using PrompterLive.Core.Services.Streaming;
 
@@ -7,36 +6,14 @@ namespace PrompterLive.Shared.Pages;
 
 public partial class GoLivePage
 {
-    private const string DestinationDisabledSummary = "Disabled until you arm this destination.";
+    private const string DestinationDisabledSummary = "Disabled in this live session.";
     private const string DestinationDisabledStatusLabel = "Disabled";
     private const string DestinationEnabledStatusLabel = "Ready";
-    private const string DestinationLocalSummarySuffix = " camera source(s) armed for this destination.";
+    private const string DestinationLocalSummarySuffix = " source(s) armed for this output.";
     private const string DestinationNeedsSetupStatusLabel = "Needs setup";
-    private const string DestinationNoSourceSummary = "Select at least one scene camera for this destination.";
-    private const string DestinationRemoteReadySummary = "Credentials and source routing are stored in browser settings.";
-    private const string DestinationRemoteSetupSummary = "Complete the destination fields and source routing before going live.";
-    private const string GoLiveLiveKitDescription = "Keep LiveKit ingest credentials on the live screen so routing can be armed without leaving the studio.";
-    private const string GoLiveProgramControlDescription = "Keep the active canvas output tuned before the live session starts.";
-    private const string GoLiveProgramControlTitle = "Program Control";
-    private const string GoLiveRecordingDescription = "Arm local recording before you start the program so the session can roll immediately.";
-    private const string GoLiveYoutubeDescription = "Store YouTube RTMP credentials on the routing surface and arm sources next to the live canvas.";
-    private const string ObsStudioDescription = "Keep the browser canvas available to OBS Virtual Camera for desktop capture workflows.";
-    private const string OutputResolutionFieldLabel = "Output Resolution";
-    private const string BitrateFieldLabel = "Bitrate (kbps)";
-    private const string ShowTextOverlayFieldLabel = "Show Text Overlay";
-    private const string IncludeCameraInOutputFieldLabel = "Include Camera in Output";
-    private const string LiveKitServerFieldLabel = "Server URL";
-    private const string LiveKitRoomFieldLabel = "Room Name";
-    private const string LiveKitTokenFieldLabel = "Access Token";
-    private const string YoutubeUrlFieldLabel = "RTMP / RTMPS URL";
-    private const string YoutubeKeyFieldLabel = "Stream Key";
-    private const string RoutingControlsDescription = "Arm destinations, tune the outbound program, and keep source routing beside the live canvas.";
-    private const string RoutingControlsEyebrow = "Go Live Routing";
-    private const string RoutingControlsTitle = "Program outputs";
-
-    private string RoutingControlsSubtitle => HasAnyLiveOutput
-        ? PrimarySessionBadge
-        : DestinationDisabledStatusLabel;
+    private const string DestinationNoSourceSummary = "No routed source is armed for this destination yet.";
+    private const string DestinationRemoteReadySummary = "Credentials and source routing are ready in Settings.";
+    private const string DestinationRemoteSetupSummary = "Complete provider setup in Settings before going live.";
 
     private IReadOnlyList<string> GetSelectedSourceIds(string targetId) =>
         GoLiveDestinationRouting.GetSelectedSourceIds(_studioSettings.Streaming, targetId, SceneCameras);
@@ -158,154 +135,4 @@ public partial class GoLivePage
 
         await PersistStudioSettingsAsync();
     }
-
-    private async Task ToggleDestinationSourceAsync((string TargetId, string SourceId) update)
-    {
-        await EnsurePageReadyAsync();
-
-        _studioSettings = _studioSettings with
-        {
-            Streaming = GoLiveDestinationRouting.ToggleSource(
-                _studioSettings.Streaming,
-                update.TargetId,
-                update.SourceId,
-                SceneCameras)
-        };
-
-        await PersistStudioSettingsAsync();
-    }
-
-    private async Task OnGoLiveOutputResolutionChanged(ChangeEventArgs args)
-    {
-        await EnsurePageReadyAsync();
-
-        if (!Enum.TryParse<StreamingResolutionPreset>(args.Value?.ToString(), out var outputResolution))
-        {
-            return;
-        }
-
-        _studioSettings = _studioSettings with
-        {
-            Streaming = _studioSettings.Streaming with { OutputResolution = outputResolution }
-        };
-
-        await PersistStudioSettingsAsync();
-    }
-
-    private async Task UpdateStreamingBitrateAsync(ChangeEventArgs args)
-    {
-        await EnsurePageReadyAsync();
-
-        if (!int.TryParse(args.Value?.ToString(), out var bitrate))
-        {
-            return;
-        }
-
-        _studioSettings = _studioSettings with
-        {
-            Streaming = _studioSettings.Streaming with { BitrateKbps = Math.Max(250, bitrate) }
-        };
-
-        await PersistStudioSettingsAsync();
-    }
-
-    private async Task ToggleGoLiveTextOverlayAsync()
-    {
-        await EnsurePageReadyAsync();
-
-        _studioSettings = _studioSettings with
-        {
-            Streaming = _studioSettings.Streaming with
-            {
-                ShowTextOverlay = !_studioSettings.Streaming.ShowTextOverlay
-            }
-        };
-
-        await PersistStudioSettingsAsync();
-    }
-
-    private async Task ToggleGoLiveIncludeCameraAsync()
-    {
-        await EnsurePageReadyAsync();
-
-        var nextValue = !_studioSettings.Streaming.IncludeCameraInOutput;
-        _studioSettings = _studioSettings with
-        {
-            Streaming = _studioSettings.Streaming with { IncludeCameraInOutput = nextValue }
-        };
-
-        foreach (var camera in SceneCameras)
-        {
-            MediaSceneService.SetIncludeInOutput(camera.SourceId, nextValue);
-        }
-
-        await PersistSceneAsync();
-        _studioSettings = _studioSettings with
-        {
-            Streaming = GoLiveDestinationRouting.Normalize(_studioSettings.Streaming, SceneCameras)
-        };
-        await PersistStudioSettingsAsync();
-    }
-
-    private async Task UpdateLiveKitServerAsync(ChangeEventArgs args)
-    {
-        await EnsurePageReadyAsync();
-
-        _studioSettings = _studioSettings with
-        {
-            Streaming = _studioSettings.Streaming with { LiveKitServerUrl = GetInputValue(args) }
-        };
-
-        await PersistStudioSettingsAsync();
-    }
-
-    private async Task UpdateLiveKitRoomAsync(ChangeEventArgs args)
-    {
-        await EnsurePageReadyAsync();
-
-        _studioSettings = _studioSettings with
-        {
-            Streaming = _studioSettings.Streaming with { LiveKitRoomName = GetInputValue(args) }
-        };
-
-        await PersistStudioSettingsAsync();
-    }
-
-    private async Task UpdateLiveKitTokenAsync(ChangeEventArgs args)
-    {
-        await EnsurePageReadyAsync();
-
-        _studioSettings = _studioSettings with
-        {
-            Streaming = _studioSettings.Streaming with { LiveKitToken = GetInputValue(args) }
-        };
-
-        await PersistStudioSettingsAsync();
-    }
-
-    private async Task UpdateYoutubeUrlAsync(ChangeEventArgs args)
-    {
-        await EnsurePageReadyAsync();
-
-        _studioSettings = _studioSettings with
-        {
-            Streaming = _studioSettings.Streaming with { YoutubeRtmpUrl = GetInputValue(args) }
-        };
-
-        await PersistStudioSettingsAsync();
-    }
-
-    private async Task UpdateYoutubeKeyAsync(ChangeEventArgs args)
-    {
-        await EnsurePageReadyAsync();
-
-        _studioSettings = _studioSettings with
-        {
-            Streaming = _studioSettings.Streaming with { YoutubeStreamKey = GetInputValue(args) }
-        };
-
-        await PersistStudioSettingsAsync();
-    }
-
-    private static string GetInputValue(ChangeEventArgs args) => args.Value?.ToString() ?? string.Empty;
 }

--- a/src/PrompterLive.Shared/GoLive/Pages/GoLivePage.StudioSurface.cs
+++ b/src/PrompterLive.Shared/GoLive/Pages/GoLivePage.StudioSurface.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using PrompterLive.Core.Models.Media;
 using PrompterLive.Core.Models.Workspace;
 using PrompterLive.Shared.Components.GoLive;
 
@@ -17,6 +18,10 @@ public partial class GoLivePage
     private const string CustomScenePrefix = "custom-scene-";
     private const string CustomSceneTitlePrefix = "Scene ";
     private const string DetailLocalProgramLabel = "Local program";
+    private const string DestinationToneLiveKit = "livekit";
+    private const string DestinationToneLocal = "local";
+    private const string DestinationToneRecording = "recording";
+    private const string DestinationToneYoutube = "youtube";
     private const string GuestRoomLabel = "Guest room";
     private const string HostParticipantId = "host";
     private const string HostParticipantInitial = "H";
@@ -34,6 +39,7 @@ public partial class GoLivePage
     private const string RecordingMetricLabel = "Recording";
     private const string RecordingReadyDetailLabel = "Ready";
     private const string RecordingReadyMetricValue = "Armed";
+    private const string RelayPlatformLabel = "Relay preset";
     private const string RemoteTalentSourceId = "prompter-display";
     private const string RemoteTalentTitle = "Prompter Display";
     private const string RoomCodeFallback = "local-studio";
@@ -48,12 +54,12 @@ public partial class GoLivePage
     private const string ScreenShareSourceId = "screen-share";
     private const string ScreenShareTitle = "Share Screen";
     private const string SecondarySceneId = "scene-secondary";
+    private const string SettingsPlatformLabel = "Settings preset";
     private const string StatusBitrateLabel = "Bitrate";
     private const string StatusOutputLabel = "Output";
     private const string SessionMetricLabel = "Session";
     private const string SlidesSourceId = "slides";
     private const string SlidesSourceTitle = "Slides";
-    private const string StreamPlatformLabel = "Broadcast";
     private const string UtilitySourceClickLabel = "Click to share";
     private const string UtilitySourcePrompterBadge = "Prompter";
     private const string UtilitySourceShareBadge = "Add";
@@ -85,13 +91,7 @@ public partial class GoLivePage
 
     private IReadOnlyList<GoLiveAudioChannelViewModel> AudioChannels => BuildAudioChannels();
 
-    private IReadOnlyList<GoLiveDestinationSummaryViewModel> DestinationSummary =>
-    [
-        new(GoLiveTargetCatalog.TargetIds.Youtube, GoLiveTargetCatalog.TargetNames.Youtube, StreamPlatformLabel, _studioSettings.Streaming.YoutubeEnabled),
-        new(GoLiveTargetCatalog.TargetIds.Obs, GoLiveTargetCatalog.TargetNames.Obs, StreamPlatformLabel, _studioSettings.Streaming.ObsVirtualCameraEnabled),
-        new(GoLiveTargetCatalog.TargetIds.LiveKit, GoLiveTargetCatalog.TargetNames.LiveKit, GuestRoomLabel, _studioSettings.Streaming.LiveKitEnabled),
-        new(GoLiveTargetCatalog.TargetIds.Recording, GoLiveTargetCatalog.TargetNames.Recording, ActiveWorkLabel, _studioSettings.Streaming.LocalRecordingEnabled)
-    ];
+    private IReadOnlyList<GoLiveDestinationSummaryViewModel> DestinationSummary => BuildDestinationSummary();
 
     private bool IsRoomActive =>
         _roomCreated
@@ -110,6 +110,11 @@ public partial class GoLivePage
     private IReadOnlyList<GoLiveMetricViewModel> StatusMetrics => BuildStatusMetrics();
 
     private static IReadOnlyList<GoLiveUtilitySourceViewModel> UtilitySources => StudioUtilitySources;
+
+    private bool CanAddSceneCamera =>
+        _mediaDevices.Any(device =>
+            device.Kind == MediaDeviceKind.Camera
+            && SceneCameras.All(camera => !string.Equals(camera.DeviceId, device.DeviceId, StringComparison.Ordinal)));
 
     private void EnsureStudioSurfaceState()
     {
@@ -253,6 +258,81 @@ public partial class GoLivePage
             (false, false, true) => RuntimeEngineRecorderValue,
             _ => RuntimeEngineIdleValue
         };
+    }
+
+    private IReadOnlyList<GoLiveDestinationSummaryViewModel> BuildDestinationSummary()
+    {
+        return
+        [
+            BuildDestinationSummary(
+                GoLiveTargetCatalog.TargetIds.Obs,
+                GoLiveTargetCatalog.TargetNames.Obs,
+                SettingsPlatformLabel,
+                _studioSettings.Streaming.ObsVirtualCameraEnabled,
+                DestinationToneLocal),
+            BuildDestinationSummary(
+                GoLiveTargetCatalog.TargetIds.Recording,
+                GoLiveTargetCatalog.TargetNames.Recording,
+                ActiveWorkLabel,
+                _studioSettings.Streaming.LocalRecordingEnabled,
+                DestinationToneRecording),
+            BuildRemoteDestinationSummary(
+                GoLiveTargetCatalog.TargetIds.LiveKit,
+                GoLiveTargetCatalog.TargetNames.LiveKit,
+                GuestRoomLabel,
+                _studioSettings.Streaming.LiveKitEnabled,
+                DestinationToneLiveKit,
+                _studioSettings.Streaming.LiveKitServerUrl,
+                _studioSettings.Streaming.LiveKitRoomName,
+                _studioSettings.Streaming.LiveKitToken),
+            BuildRemoteDestinationSummary(
+                GoLiveTargetCatalog.TargetIds.Youtube,
+                GoLiveTargetCatalog.TargetNames.Youtube,
+                RelayPlatformLabel,
+                _studioSettings.Streaming.YoutubeEnabled,
+                DestinationToneYoutube,
+                _studioSettings.Streaming.YoutubeRtmpUrl,
+                _studioSettings.Streaming.YoutubeStreamKey)
+        ];
+    }
+
+    private GoLiveDestinationSummaryViewModel BuildDestinationSummary(
+        string targetId,
+        string name,
+        string platformLabel,
+        bool isEnabled,
+        string tone)
+    {
+        var isReady = BuildDestinationIsReady(isEnabled, targetId);
+        return new GoLiveDestinationSummaryViewModel(
+            targetId,
+            name,
+            platformLabel,
+            isEnabled,
+            isReady,
+            BuildLocalSummary(targetId),
+            BuildTargetStatusLabel(isEnabled, targetId),
+            tone);
+    }
+
+    private GoLiveDestinationSummaryViewModel BuildRemoteDestinationSummary(
+        string targetId,
+        string name,
+        string platformLabel,
+        bool isEnabled,
+        string tone,
+        params string[] requiredValues)
+    {
+        var isReady = BuildDestinationIsReady(isEnabled, targetId, requiredValues);
+        return new GoLiveDestinationSummaryViewModel(
+            targetId,
+            name,
+            platformLabel,
+            isEnabled,
+            isReady,
+            BuildRemoteSummary(isEnabled, targetId, requiredValues),
+            BuildTargetStatusLabel(isEnabled, targetId, requiredValues),
+            tone);
     }
 
     private async Task ToggleDestinationSummaryAsync(string targetId)

--- a/src/PrompterLive.Shared/GoLive/Pages/GoLivePage.razor
+++ b/src/PrompterLive.Shared/GoLive/Pages/GoLivePage.razor
@@ -64,26 +64,27 @@
         <section class="go-live-studio-shell">
             @if (_showLeftRail)
             {
-                <div class="go-live-left-rail">
+                <aside class="go-live-left-rail">
                     <GoLiveSourcesCard Sources="@SceneCameras"
                                        ActiveSourceId="@ActiveCamera?.SourceId"
                                        SelectedSourceId="@SelectedCamera?.SourceId"
                                        CurrentScriptTitle="@_screenTitle"
                                        CurrentScriptProgressLabel="@CurrentScriptProgressLabel"
                                        UtilitySources="@UtilitySources"
-                                       SettingsRoute="@AppRoutes.Settings"
                                        HasPrimaryMicrophone="@HasPrimaryMicrophone"
                                        MicrophoneName="@PrimaryMicrophoneLabel"
                                        MicrophoneRouteLabel="@(HasPrimaryMicrophone ? PrimaryMicrophoneRoute : NoMicrophoneLabel)"
+                                       CanAddCamera="@CanAddSceneCamera"
+                                       AddCamera="AddAvailableCameraAsync"
                                        SelectSource="SelectSourceAsync"
                                        ToggleSource="ToggleSceneOutputAsync" />
-                </div>
+                </aside>
             }
 
             <div class="go-live-center-stage">
                 <GoLiveProgramFeedCard ActiveSourceLabel="@ActiveSourceLabel"
                                        ActiveSessionLabel="@ActiveSessionLabel"
-                                       Camera="@ActiveCamera"
+                                       Camera="@SelectedCamera"
                                        IsArmed="@HasAnyLiveOutput"
                                        IsRecordingActive="@GoLiveSession.State.IsRecordingActive"
                                        IsStreamActive="@GoLiveSession.State.IsStreamActive"
@@ -110,9 +111,11 @@
                        data-testid="@UiTestIds.GoLive.PreviewRail">
                     <GoLiveCameraPreviewCard Camera="@ActiveCamera"
                                              CanSwitchProgram="@CanSwitchProgram"
+                                             Description="@ActiveSessionLabel"
                                              ShowSwitchAction="true"
                                              SwitchActionLabel="@SwitchActionLabel"
-                                             SwitchSelectedSource="SwitchSelectedSourceAsync" />
+                                             SwitchSelectedSource="SwitchSelectedSourceAsync"
+                                             Title="Live" />
 
                     <GoLiveStudioSidebar ActiveTab="@_activeStudioTab"
                                          AudioChannels="@AudioChannels"
@@ -122,10 +125,11 @@
                                          IsRoomActive="@IsRoomActive"
                                          MuteAllGuests="@_muteAllGuests"
                                          Participants="@Participants"
-                                          RoomCode="@RoomCode"
+                                         RoomCode="@RoomCode"
                                          RuntimeMetrics="@RuntimeMetrics"
                                          SelectTab="SelectStudioTabAsync"
                                          SendCue="SendCueAsync"
+                                         SettingsRoute="@AppRoutes.Settings"
                                          StatusMetrics="@StatusMetrics"
                                          TalkbackEnabled="@_talkbackEnabled"
                                          ToggleDestination="ToggleDestinationSummaryAsync"
@@ -145,162 +149,6 @@
                     }
                 </aside>
             }
-        </section>
-
-        <section class="go-live-routing-section">
-            <div class="go-live-routing-copy">
-                <span class="set-section-label">@RoutingControlsEyebrow</span>
-                <h3>@RoutingControlsTitle</h3>
-                <p>@RoutingControlsDescription</p>
-            </div>
-
-            <div class="go-live-routing-grid">
-                <section class="go-live-rail-card go-live-output-panel">
-                    <div class="go-live-sidebar-header">
-                        <div>
-                            <span class="go-live-sidebar-title">@GoLiveProgramControlTitle</span>
-                            <div class="live-card-desc">@GoLiveProgramControlDescription</div>
-                        </div>
-                        <span class="live-status @(HasAnyLiveOutput ? "ready" : "pending")">@RoutingControlsSubtitle</span>
-                    </div>
-
-                    <div class="set-devices go-live-output-fields">
-                        <div class="set-field">
-                            <label>@OutputResolutionFieldLabel</label>
-                            <select class="set-select"
-                                    value="@_studioSettings.Streaming.OutputResolution"
-                                    @onchange="OnGoLiveOutputResolutionChanged"
-                                    data-testid="@UiTestIds.GoLive.OutputResolution">
-                                <option value="@StreamingResolutionPreset.FullHd1080p30">1920 x 1080 &#64; 30fps</option>
-                                <option value="@StreamingResolutionPreset.FullHd1080p60">1920 x 1080 &#64; 60fps</option>
-                                <option value="@StreamingResolutionPreset.Hd720p30">1280 x 720 &#64; 30fps</option>
-                                <option value="@StreamingResolutionPreset.UltraHd2160p30">3840 x 2160 &#64; 30fps</option>
-                            </select>
-                        </div>
-
-                        <div class="set-field">
-                            <label>@BitrateFieldLabel</label>
-                            <input type="number"
-                                   class="set-input"
-                                   value="@_studioSettings.Streaming.BitrateKbps"
-                                   @oninput="UpdateStreamingBitrateAsync"
-                                   data-testid="@UiTestIds.GoLive.Bitrate" />
-                        </div>
-
-                        <div class="set-field set-field-toggle">
-                            <label>@ShowTextOverlayFieldLabel</label>
-                            <div class="set-toggle @(_studioSettings.Streaming.ShowTextOverlay ? "on" : null)"
-                                 @onclick="ToggleGoLiveTextOverlayAsync"
-                                 data-testid="@UiTestIds.GoLive.StreamTextOverlay">
-                                <div class="set-toggle-thumb"></div>
-                            </div>
-                        </div>
-
-                        <div class="set-field set-field-toggle">
-                            <label>@IncludeCameraInOutputFieldLabel</label>
-                            <div class="set-toggle @(_studioSettings.Streaming.IncludeCameraInOutput ? "on" : null)"
-                                 @onclick="ToggleGoLiveIncludeCameraAsync"
-                                 data-testid="@UiTestIds.GoLive.StreamIncludeCamera">
-                                <div class="set-toggle-thumb"></div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="live-targets-grid go-live-targets-grid">
-                        <GoLiveDestinationCard Title="@GoLiveTargetCatalog.TargetNames.Obs"
-                                               Description="@ObsStudioDescription"
-                                               Summary="@BuildLocalSummary(GoLiveTargetCatalog.TargetIds.Obs)"
-                                               StatusLabel="@BuildTargetStatusLabel(_studioSettings.Streaming.ObsVirtualCameraEnabled, GoLiveTargetCatalog.TargetIds.Obs)"
-                                               IsEnabled="@_studioSettings.Streaming.ObsVirtualCameraEnabled"
-                                               IsReady="@BuildDestinationIsReady(_studioSettings.Streaming.ObsVirtualCameraEnabled, GoLiveTargetCatalog.TargetIds.Obs)"
-                                               ToggleTestId="@UiTestIds.GoLive.ObsToggle"
-                                               CardTestId="@UiTestIds.GoLive.ProviderCard(GoLiveTargetCatalog.TargetIds.Obs)"
-                                               OnToggle="ToggleObsOutputAsync" />
-
-                        <GoLiveDestinationCard Title="@GoLiveTargetCatalog.TargetNames.Recording"
-                                               Description="@GoLiveRecordingDescription"
-                                               Summary="@BuildLocalSummary(GoLiveTargetCatalog.TargetIds.Recording)"
-                                               StatusLabel="@BuildTargetStatusLabel(_studioSettings.Streaming.LocalRecordingEnabled, GoLiveTargetCatalog.TargetIds.Recording)"
-                                               IsEnabled="@_studioSettings.Streaming.LocalRecordingEnabled"
-                                               IsReady="@BuildDestinationIsReady(_studioSettings.Streaming.LocalRecordingEnabled, GoLiveTargetCatalog.TargetIds.Recording)"
-                                               ToggleTestId="@UiTestIds.GoLive.RecordingToggle"
-                                               CardTestId="@UiTestIds.GoLive.ProviderCard(GoLiveTargetCatalog.TargetIds.Recording)"
-                                               OnToggle="ToggleRecordingOutputAsync" />
-                    </div>
-                </section>
-
-                <div class="live-targets-grid go-live-targets-grid">
-                    <GoLiveDestinationCard Title="@GoLiveTargetCatalog.TargetNames.LiveKit"
-                                           Description="@GoLiveLiveKitDescription"
-                                           Summary="@BuildRemoteSummary(_studioSettings.Streaming.LiveKitEnabled, GoLiveTargetCatalog.TargetIds.LiveKit, _studioSettings.Streaming.LiveKitServerUrl, _studioSettings.Streaming.LiveKitRoomName, _studioSettings.Streaming.LiveKitToken)"
-                                           StatusLabel="@BuildTargetStatusLabel(_studioSettings.Streaming.LiveKitEnabled, GoLiveTargetCatalog.TargetIds.LiveKit, _studioSettings.Streaming.LiveKitServerUrl, _studioSettings.Streaming.LiveKitRoomName, _studioSettings.Streaming.LiveKitToken)"
-                                           IsEnabled="@_studioSettings.Streaming.LiveKitEnabled"
-                                           IsReady="@BuildDestinationIsReady(_studioSettings.Streaming.LiveKitEnabled, GoLiveTargetCatalog.TargetIds.LiveKit, _studioSettings.Streaming.LiveKitServerUrl, _studioSettings.Streaming.LiveKitRoomName, _studioSettings.Streaming.LiveKitToken)"
-                                           ToggleTestId="@UiTestIds.GoLive.LiveKitToggle"
-                                           CardTestId="@UiTestIds.GoLive.ProviderCard(GoLiveTargetCatalog.TargetIds.LiveKit)"
-                                           OnToggle="ToggleLiveKitSettingsAsync">
-                        <GoLiveDestinationSourcePicker TargetId="@GoLiveTargetCatalog.TargetIds.LiveKit"
-                                                       Sources="@SceneCameras"
-                                                       SelectedSourceIds="@GetSelectedSourceIds(GoLiveTargetCatalog.TargetIds.LiveKit)"
-                                                       ToggleSource="@(sourceId => ToggleDestinationSourceAsync((GoLiveTargetCatalog.TargetIds.LiveKit, sourceId)))" />
-                        <div class="set-field">
-                            <label>@LiveKitServerFieldLabel</label>
-                            <input type="text"
-                                   class="set-input"
-                                   value="@_studioSettings.Streaming.LiveKitServerUrl"
-                                   @oninput="UpdateLiveKitServerAsync"
-                                   data-testid="@UiTestIds.GoLive.LiveKitServer" />
-                        </div>
-                        <div class="set-field">
-                            <label>@LiveKitRoomFieldLabel</label>
-                            <input type="text"
-                                   class="set-input"
-                                   value="@_studioSettings.Streaming.LiveKitRoomName"
-                                   @oninput="UpdateLiveKitRoomAsync"
-                                   data-testid="@UiTestIds.GoLive.LiveKitRoom" />
-                        </div>
-                        <div class="set-field">
-                            <label>@LiveKitTokenFieldLabel</label>
-                            <input type="password"
-                                   class="set-input"
-                                   value="@_studioSettings.Streaming.LiveKitToken"
-                                   @oninput="UpdateLiveKitTokenAsync"
-                                   data-testid="@UiTestIds.GoLive.LiveKitToken" />
-                        </div>
-                    </GoLiveDestinationCard>
-
-                    <GoLiveDestinationCard Title="@GoLiveTargetCatalog.TargetNames.Youtube"
-                                           Description="@GoLiveYoutubeDescription"
-                                           Summary="@BuildRemoteSummary(_studioSettings.Streaming.YoutubeEnabled, GoLiveTargetCatalog.TargetIds.Youtube, _studioSettings.Streaming.YoutubeRtmpUrl, _studioSettings.Streaming.YoutubeStreamKey)"
-                                           StatusLabel="@BuildTargetStatusLabel(_studioSettings.Streaming.YoutubeEnabled, GoLiveTargetCatalog.TargetIds.Youtube, _studioSettings.Streaming.YoutubeRtmpUrl, _studioSettings.Streaming.YoutubeStreamKey)"
-                                           IsEnabled="@_studioSettings.Streaming.YoutubeEnabled"
-                                           IsReady="@BuildDestinationIsReady(_studioSettings.Streaming.YoutubeEnabled, GoLiveTargetCatalog.TargetIds.Youtube, _studioSettings.Streaming.YoutubeRtmpUrl, _studioSettings.Streaming.YoutubeStreamKey)"
-                                           ToggleTestId="@UiTestIds.GoLive.YoutubeToggle"
-                                           CardTestId="@UiTestIds.GoLive.ProviderCard(GoLiveTargetCatalog.TargetIds.Youtube)"
-                                           OnToggle="ToggleYoutubeSettingsAsync">
-                        <GoLiveDestinationSourcePicker TargetId="@GoLiveTargetCatalog.TargetIds.Youtube"
-                                                       Sources="@SceneCameras"
-                                                       SelectedSourceIds="@GetSelectedSourceIds(GoLiveTargetCatalog.TargetIds.Youtube)"
-                                                       ToggleSource="@(sourceId => ToggleDestinationSourceAsync((GoLiveTargetCatalog.TargetIds.Youtube, sourceId)))" />
-                        <div class="set-field">
-                            <label>@YoutubeUrlFieldLabel</label>
-                            <input type="text"
-                                   class="set-input"
-                                   value="@_studioSettings.Streaming.YoutubeRtmpUrl"
-                                   @oninput="UpdateYoutubeUrlAsync"
-                                   data-testid="@UiTestIds.GoLive.YoutubeUrl" />
-                        </div>
-                        <div class="set-field">
-                            <label>@YoutubeKeyFieldLabel</label>
-                            <input type="password"
-                                   class="set-input"
-                                   value="@_studioSettings.Streaming.YoutubeStreamKey"
-                                   @oninput="UpdateYoutubeKeyAsync"
-                                   data-testid="@UiTestIds.GoLive.YoutubeKey" />
-                        </div>
-                    </GoLiveDestinationCard>
-                </div>
-            </div>
         </section>
     </div>
 </div>

--- a/src/PrompterLive.Shared/GoLive/Pages/GoLivePage.razor.cs
+++ b/src/PrompterLive.Shared/GoLive/Pages/GoLivePage.razor.cs
@@ -40,6 +40,7 @@ public partial class GoLivePage : ComponentBase
 
     private Task? _bootstrapTask;
     private readonly SemaphoreSlim _interactionGate = new(1, 1);
+    private IReadOnlyList<MediaDeviceInfo> _mediaDevices = [];
     private bool _loadState = true;
     private SettingsPagePreferences _recordingPreferences = SettingsPagePreferences.Default;
     private string _screenSubtitle = StreamingSubtitle;

--- a/src/PrompterLive.Shared/GoLive/Pages/GoLivePage.razor.css
+++ b/src/PrompterLive.Shared/GoLive/Pages/GoLivePage.razor.css
@@ -1,29 +1,26 @@
-.go-live-page {
-    padding: 0;
-}
-
 .go-live-page-shell {
     display: flex;
     flex-direction: column;
-    gap: 18px;
     min-height: 100%;
-    padding: 4px;
-    background: linear-gradient(180deg, rgba(6, 8, 14, .98), rgba(3, 5, 10, 1));
-    border: 1px solid rgba(214, 166, 91, .08);
+    background:
+        radial-gradient(circle at top right, rgba(96, 165, 250, .12), transparent 30%),
+        linear-gradient(180deg, rgba(4, 8, 15, .98), rgba(5, 8, 16, 1));
+    border: 1px solid rgba(255, 255, 255, .06);
     border-radius: 24px;
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, .05);
+    overflow: hidden;
 }
 
 .go-live-session-bar {
     position: relative;
-    z-index: 2;
     display: grid;
     grid-template-columns: auto minmax(0, 1fr) auto;
     align-items: center;
-    gap: 16px;
-    min-height: 54px;
-    padding: 0 10px;
-    border-bottom: 1px solid rgba(214, 166, 91, .06);
+    gap: 18px;
+    min-height: 56px;
+    padding: 0 16px;
+    border-bottom: 1px solid rgba(255, 255, 255, .06);
+    background: rgba(8, 11, 18, .78);
+    backdrop-filter: blur(16px);
 }
 
 .go-live-session-bar-left,
@@ -41,7 +38,9 @@
 
 .go-live-session-bar-left strong {
     color: rgba(255, 245, 224, .92);
-    font-size: 13px;
+    font-size: 14px;
+    font-weight: 700;
+    letter-spacing: -.02em;
     white-space: nowrap;
 }
 
@@ -54,47 +53,43 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    min-height: 28px;
+    min-height: 32px;
     padding: 0 12px;
-    border-radius: 999px;
-    text-decoration: none;
-    font-size: 10px;
+    border-radius: 10px;
+    font-size: 11px;
     font-weight: 700;
     letter-spacing: .08em;
+    text-decoration: none;
     text-transform: uppercase;
 }
 
-.go-live-back-link {
-    border: 1px solid rgba(214, 166, 91, .1);
-    color: rgba(248, 241, 226, .68);
-    background: rgba(255, 255, 255, .02);
-}
-
+.go-live-back-link,
 .go-live-panel-toggle,
 .go-live-settings-shortcut {
-    border: 1px solid rgba(214, 166, 91, .1);
-    color: rgba(248, 241, 226, .52);
-    background: rgba(255, 255, 255, .02);
+    border: 1px solid rgba(255, 255, 255, .08);
+    background: rgba(255, 255, 255, .03);
+    color: rgba(248, 241, 226, .64);
 }
 
-.go-live-panel-toggle.active {
-    color: rgba(255, 245, 224, .9);
-    border-color: rgba(214, 166, 91, .22);
-    background: rgba(111, 43, 20, .24);
+.go-live-panel-toggle.active,
+.go-live-settings-shortcut:hover,
+.go-live-back-link:hover {
+    color: rgba(255, 245, 224, .94);
+    border-color: rgba(196, 160, 96, .28);
+    background: rgba(196, 160, 96, .12);
 }
 
 .go-live-live-badge,
 .go-live-record-pill {
-    border: 1px solid rgba(255, 120, 120, .14);
-    color: #f28e8e;
-    background: rgba(90, 24, 24, .22);
+    border: 1px solid rgba(255, 107, 107, .22);
+    background: rgba(255, 68, 68, .1);
+    color: #ff8d8d;
 }
 
 .go-live-stream-pill {
-    margin-left: auto;
-    border: 1px solid rgba(214, 166, 91, .14);
-    color: #f4d9b0;
-    background: rgba(111, 43, 20, .22);
+    border: 1px solid rgba(16, 185, 129, .28);
+    background: rgba(16, 185, 129, .1);
+    color: #59d8a7;
 }
 
 .go-live-record-pill:disabled,
@@ -104,11 +99,11 @@
 
 .go-live-session-timer {
     justify-self: center;
-    color: #f28e8e;
+    color: #ff8d8d;
     font-family: var(--font-mono);
-    font-size: 13px;
-    font-weight: 700;
-    letter-spacing: .18em;
+    font-size: 18px;
+    font-weight: 600;
+    letter-spacing: .2em;
 }
 
 .go-live-mode-switch {
@@ -116,19 +111,19 @@
     align-items: center;
     gap: 4px;
     padding: 3px;
-    border: 1px solid rgba(214, 166, 91, .08);
-    border-radius: 999px;
-    background: rgba(255, 255, 255, .02);
+    border-radius: 12px;
+    background: rgba(0, 0, 0, .3);
+    border: 1px solid rgba(255, 255, 255, .06);
 }
 
 .go-live-mode-button {
-    min-height: 28px;
+    min-height: 30px;
     padding: 0 12px;
-    border: none;
-    border-radius: 999px;
+    border: 1px solid transparent;
+    border-radius: 9px;
     background: transparent;
     color: rgba(248, 241, 226, .42);
-    font-size: 10px;
+    font-size: 11px;
     font-weight: 700;
     letter-spacing: .08em;
     text-transform: uppercase;
@@ -136,43 +131,53 @@
 
 .go-live-mode-button.active {
     color: rgba(255, 245, 224, .96);
-    background: rgba(111, 43, 20, .3);
+    border-color: rgba(255, 255, 255, .08);
+    background: rgba(255, 255, 255, .08);
 }
 
 .go-live-studio-shell {
-    position: relative;
-    z-index: 1;
+    flex: 1;
     display: grid;
-    grid-template-columns: 124px minmax(0, 1fr) 176px;
-    gap: 14px;
+    grid-template-columns: minmax(220px, 280px) minmax(0, 1fr) minmax(290px, 340px);
     min-height: 720px;
-    padding: 12px 6px 6px;
 }
 
 .go-live-left-rail,
-.go-live-right-rail,
-.go-live-center-stage {
+.go-live-center-stage,
+.go-live-right-rail {
     min-width: 0;
+    min-height: 0;
+}
+
+.go-live-left-rail {
+    padding: 12px;
+    border-right: 1px solid rgba(255, 255, 255, .05);
+    background: rgba(255, 255, 255, .01);
 }
 
 .go-live-center-stage {
     display: flex;
     flex-direction: column;
     gap: 12px;
+    padding: 12px;
+    min-height: 0;
 }
 
 .go-live-right-rail {
     display: flex;
     flex-direction: column;
     gap: 12px;
+    padding: 12px;
+    border-left: 1px solid rgba(255, 255, 255, .05);
+    background: rgba(255, 255, 255, .01);
 }
 
 .go-live-page-shell[data-left-open="False"][data-right-open="True"][data-full-program="False"] .go-live-studio-shell {
-    grid-template-columns: minmax(0, 1fr) 176px;
+    grid-template-columns: minmax(0, 1fr) minmax(290px, 340px);
 }
 
 .go-live-page-shell[data-left-open="True"][data-right-open="False"][data-full-program="False"] .go-live-studio-shell {
-    grid-template-columns: 124px minmax(0, 1fr);
+    grid-template-columns: minmax(220px, 280px) minmax(0, 1fr);
 }
 
 .go-live-page-shell[data-left-open="False"][data-right-open="False"][data-full-program="False"] .go-live-studio-shell,
@@ -180,198 +185,58 @@
     grid-template-columns: minmax(0, 1fr);
 }
 
-.go-live-rail-card {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-    padding: 10px;
-    border: 1px solid rgba(214, 166, 91, .08);
-    border-radius: 18px;
-    background: rgba(6, 9, 18, .88);
-}
-
-.go-live-stat-grid {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 10px 12px;
-}
-
-.go-live-stat-grid div,
-.go-live-meter-row {
-    display: grid;
-    gap: 4px;
-}
-
-.go-live-stat-grid span,
-.go-live-meter-row span {
-    color: rgba(248, 241, 226, .34);
-    font-size: 9px;
-    font-weight: 700;
-    letter-spacing: .1em;
-    text-transform: uppercase;
-}
-
-.go-live-stat-grid strong,
-.go-live-meter-row strong {
-    color: rgba(255, 245, 224, .84);
-    font-size: 11px;
-    line-height: 1.35;
-}
-
-.go-live-stat-grid-compact strong:last-child {
-    color: #7ff3bf;
-}
-
-.go-live-meter-grid {
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-}
-
-.go-live-meter-row {
-    grid-template-columns: 28px minmax(0, 1fr) auto;
-    align-items: center;
-    gap: 8px;
-}
-
-.go-live-meter {
-    position: relative;
-    overflow: hidden;
-    height: 3px;
-    border-radius: 999px;
-    background: rgba(255, 255, 255, .08);
-}
-
-.go-live-meter-fill {
-    display: block;
-    height: 100%;
-    border-radius: inherit;
-    background: linear-gradient(90deg, #36caa0, #7ff3bf);
-}
-
-.go-live-meter-fill-primary {
-    width: 78%;
-}
-
-.go-live-meter-fill-secondary {
-    width: 46%;
-}
-
-.go-live-meter-fill-tertiary {
-    width: 58%;
-}
-
-.go-live-settings-hint {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    padding-top: 4px;
-    border-top: 1px solid rgba(214, 166, 91, .08);
-}
-
-.go-live-routing-section {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
-    padding: 0 10px 10px;
-    border-top: 1px solid rgba(214, 166, 91, .06);
-}
-
-.go-live-routing-copy {
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-}
-
-.go-live-routing-copy h3 {
-    margin: 0;
-    color: rgba(255, 245, 224, .92);
-    font-size: 18px;
-    font-weight: 700;
-}
-
-.go-live-routing-copy p {
-    margin: 0;
-    color: rgba(248, 241, 226, .48);
-    font-size: 13px;
-    line-height: 1.5;
-}
-
-.go-live-routing-grid {
-    display: grid;
-    grid-template-columns: minmax(0, 1.05fr) minmax(0, 1.45fr);
-    gap: 18px;
-    align-items: start;
-}
-
-.go-live-output-panel {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
-    min-height: 100%;
-}
-
-.go-live-output-fields {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-}
-
-.go-live-targets-grid {
-    align-content: start;
-}
-
 .live-session-links {
     display: flex;
-    flex-wrap: wrap;
     gap: 10px;
+}
+
+.live-session-links > a {
+    flex: 1;
+    justify-content: center;
 }
 
 @media (max-width: 1320px) {
-    .go-live-studio-shell,
-    .go-live-routing-grid,
-    .live-targets-grid,
-    .live-local-grid {
-        grid-template-columns: 1fr;
-    }
-
     .go-live-studio-shell {
-        min-height: auto;
+        grid-template-columns: minmax(210px, 250px) minmax(0, 1fr) minmax(260px, 300px);
     }
+}
 
+@media (max-width: 1120px) {
     .go-live-session-bar {
         grid-template-columns: 1fr;
         justify-items: stretch;
+        padding: 12px;
     }
 
     .go-live-session-timer {
         justify-self: start;
     }
 
-    .go-live-stream-pill {
-        margin-left: 0;
+    .go-live-studio-shell,
+    .go-live-page-shell[data-left-open="False"][data-right-open="True"][data-full-program="False"] .go-live-studio-shell,
+    .go-live-page-shell[data-left-open="True"][data-right-open="False"][data-full-program="False"] .go-live-studio-shell {
+        grid-template-columns: 1fr;
     }
 
-    .go-live-mode-switch {
-        width: 100%;
-        justify-content: stretch;
-    }
-
-    .go-live-mode-button {
-        flex: 1;
+    .go-live-left-rail,
+    .go-live-right-rail {
+        border: none;
+        border-top: 1px solid rgba(255, 255, 255, .05);
     }
 }
 
 @media (max-width: 720px) {
-    .go-live-page-shell {
-        padding: 2px;
-    }
-
-    .go-live-session-bar-left,
-    .go-live-session-actions {
+    .go-live-session-actions,
+    .go-live-session-bar-left {
         flex-wrap: wrap;
     }
 
-    .go-live-output-fields,
-    .go-live-stat-grid {
-        grid-template-columns: 1fr;
+    .go-live-session-timer {
+        font-size: 15px;
+        letter-spacing: .12em;
+    }
+
+    .live-session-links {
+        flex-direction: column;
     }
 }

--- a/tests/PrompterLive.App.Tests/GoLive/GoLivePageTests.cs
+++ b/tests/PrompterLive.App.Tests/GoLive/GoLivePageTests.cs
@@ -35,24 +35,16 @@ public sealed class GoLivePageTests : BunitContext
         cut.WaitForAssertion(() => Assert.Contains(UiTestIds.GoLive.Page, cut.Markup, StringComparison.Ordinal));
 
         cut.FindByTestId(UiTestIds.GoLive.LiveKitToggle).Click();
-        cut.FindByTestId(UiTestIds.GoLive.LiveKitServer).Input(AppTestData.GoLive.LiveKitServer);
-        cut.FindByTestId(UiTestIds.GoLive.LiveKitRoom).Input(AppTestData.GoLive.LiveKitRoom);
-        cut.FindByTestId(UiTestIds.GoLive.LiveKitToken).Input(AppTestData.GoLive.LiveKitToken);
         cut.FindByTestId(UiTestIds.GoLive.YoutubeToggle).Click();
-        cut.FindByTestId(UiTestIds.GoLive.YoutubeUrl).Input(AppTestData.GoLive.YoutubeUrl);
-        cut.FindByTestId(UiTestIds.GoLive.YoutubeKey).Input(AppTestData.GoLive.YoutubeKey);
-        cut.FindByTestId(UiTestIds.GoLive.Bitrate).Input(AppTestData.Streaming.BitrateKbps);
+        cut.FindByTestId(UiTestIds.GoLive.RecordingToggle).Click();
 
-        var settings = _harness.JsRuntime.GetSavedValue<StudioSettings>(StudioSettingsStore.StorageKey);
-
-        Assert.True(settings.Streaming.LiveKitEnabled);
-        Assert.Equal(AppTestData.GoLive.LiveKitServer, settings.Streaming.LiveKitServerUrl);
-        Assert.Equal(AppTestData.GoLive.LiveKitRoom, settings.Streaming.LiveKitRoomName);
-        Assert.Equal(AppTestData.GoLive.LiveKitToken, settings.Streaming.LiveKitToken);
-        Assert.True(settings.Streaming.YoutubeEnabled);
-        Assert.Equal(AppTestData.GoLive.YoutubeUrl, settings.Streaming.YoutubeRtmpUrl);
-        Assert.Equal(AppTestData.GoLive.YoutubeKey, settings.Streaming.YoutubeStreamKey);
-        Assert.Equal(AppTestData.Streaming.BitrateKbps, settings.Streaming.BitrateKbps);
+        cut.WaitForAssertion(() =>
+        {
+            var settings = _harness.JsRuntime.GetSavedValue<StudioSettings>(StudioSettingsStore.StorageKey);
+            Assert.True(settings.Streaming.LiveKitEnabled);
+            Assert.True(settings.Streaming.YoutubeEnabled);
+            Assert.True(settings.Streaming.LocalRecordingEnabled);
+        });
     }
 
     [Fact]
@@ -127,15 +119,6 @@ public sealed class GoLivePageTests : BunitContext
 
         cut.WaitForAssertion(() =>
         {
-            Assert.Equal(
-                AppTestData.GoLive.LiveKitServer,
-                cut.FindByTestId(UiTestIds.GoLive.LiveKitServer).GetAttribute("value"));
-            Assert.Equal(
-                AppTestData.GoLive.LiveKitRoom,
-                cut.FindByTestId(UiTestIds.GoLive.LiveKitRoom).GetAttribute("value"));
-            Assert.Equal(
-                AppTestData.GoLive.YoutubeUrl,
-                cut.FindByTestId(UiTestIds.GoLive.YoutubeUrl).GetAttribute("value"));
             Assert.Contains(
                 "on",
                 cut.FindByTestId(UiTestIds.GoLive.LiveKitToggle).ClassName,
@@ -144,23 +127,19 @@ public sealed class GoLivePageTests : BunitContext
                 "on",
                 cut.FindByTestId(UiTestIds.GoLive.YoutubeToggle).ClassName,
                 StringComparison.Ordinal);
-            Assert.DoesNotContain(
-                "on",
-                cut.FindByTestId(UiTestIds.GoLive.ProviderSourceToggle(
-                    GoLiveTargetCatalog.TargetIds.LiveKit,
-                    AppTestData.Camera.FirstSourceId)).ClassName!.Split(' ', StringSplitOptions.RemoveEmptyEntries),
-                StringComparer.Ordinal);
             Assert.Contains(
-                "on",
-                cut.FindByTestId(UiTestIds.GoLive.ProviderSourceToggle(
-                    GoLiveTargetCatalog.TargetIds.LiveKit,
-                    AppTestData.Camera.SecondSourceId)).ClassName!.Split(' ', StringSplitOptions.RemoveEmptyEntries),
-                StringComparer.Ordinal);
+                "Credentials and source routing are ready in Settings.",
+                cut.FindByTestId(UiTestIds.GoLive.ProviderCard(GoLiveTargetCatalog.TargetIds.LiveKit)).TextContent,
+                StringComparison.Ordinal);
+            Assert.Contains(
+                "Credentials and source routing are ready in Settings.",
+                cut.FindByTestId(UiTestIds.GoLive.ProviderCard(GoLiveTargetCatalog.TargetIds.Youtube)).TextContent,
+                StringComparison.Ordinal);
         });
     }
 
     [Fact]
-    public void GoLivePage_PersistsPerDestinationSourceRouting()
+    public void GoLivePage_SelectsSecondCameraForCanvas()
     {
         SeedSceneState(CreateTwoCameraScene());
 
@@ -170,26 +149,14 @@ public sealed class GoLivePageTests : BunitContext
         var cut = Render<GoLivePage>();
 
         cut.WaitForAssertion(() =>
-            Assert.NotNull(cut.FindByTestId(UiTestIds.GoLive.ProviderSourcePicker(GoLiveTargetCatalog.TargetIds.LiveKit))));
+            Assert.Equal(2, cut.FindAll($"[data-testid^='{UiTestIds.GoLive.SourceCameraSelect(string.Empty)}']").Count));
 
-        cut.FindByTestId(UiTestIds.GoLive.ProviderSourceToggle(
-            GoLiveTargetCatalog.TargetIds.LiveKit,
-            AppTestData.Camera.SecondSourceId)).Click();
-        cut.FindByTestId(UiTestIds.GoLive.ProviderSourceToggle(
-            GoLiveTargetCatalog.TargetIds.Youtube,
-            AppTestData.Camera.SecondSourceId)).Click();
-        cut.FindByTestId(UiTestIds.GoLive.ProviderSourceToggle(
-            GoLiveTargetCatalog.TargetIds.Youtube,
-            AppTestData.Camera.FirstSourceId)).Click();
+        cut.FindByTestId(UiTestIds.GoLive.SourceCameraSelect(AppTestData.Camera.SecondSourceId)).Click();
 
-        var settings = _harness.JsRuntime.GetSavedValue<StudioSettings>(StudioSettingsStore.StorageKey);
-        var liveKitSelection = settings.Streaming.DestinationSourceSelections!
-            .Single(selection => selection.TargetId == GoLiveTargetCatalog.TargetIds.LiveKit);
-        var youtubeSelection = settings.Streaming.DestinationSourceSelections!
-            .Single(selection => selection.TargetId == GoLiveTargetCatalog.TargetIds.Youtube);
-
-        Assert.Equal([AppTestData.Camera.FirstSourceId, AppTestData.Camera.SecondSourceId], liveKitSelection.SourceIds);
-        Assert.Equal([AppTestData.Camera.SecondSourceId], youtubeSelection.SourceIds);
+        cut.WaitForAssertion(() =>
+            Assert.Equal(
+                AppTestData.Camera.SideCamera,
+                cut.FindByTestId(UiTestIds.GoLive.SelectedSourceLabel).TextContent.Trim()));
     }
 
     [Fact]

--- a/tests/PrompterLive.App.UITests/GoLive/GoLiveFlowTests.cs
+++ b/tests/PrompterLive.App.UITests/GoLive/GoLiveFlowTests.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using PrompterLive.Core.Models.Workspace;
 using PrompterLive.Shared.Contracts;
 using static Microsoft.Playwright.Assertions;
 
@@ -10,7 +9,7 @@ public sealed class GoLiveFlowTests(StandaloneAppFixture fixture) : IClassFixtur
     private readonly StandaloneAppFixture _fixture = fixture;
 
     [Fact]
-    public async Task GoLivePage_ArmsDestinationsAndPersistsValuesInBrowserStorage()
+    public async Task GoLivePage_ArmsDestinationsAndPersistsOperationalToggles()
     {
         var page = await _fixture.NewPageAsync();
 
@@ -23,42 +22,20 @@ public sealed class GoLiveFlowTests(StandaloneAppFixture fixture) : IClassFixtur
             await Expect(page.GetByTestId(UiTestIds.GoLive.SourcesCard)).ToBeVisibleAsync();
 
             await page.GetByTestId(UiTestIds.GoLive.LiveKitToggle).ClickAsync();
-            await page.GetByTestId(UiTestIds.GoLive.LiveKitServer).FillAsync(BrowserTestConstants.GoLive.LiveKitServer);
-            await page.GetByTestId(UiTestIds.GoLive.LiveKitRoom).FillAsync(BrowserTestConstants.GoLive.LiveKitRoom);
-            await page.GetByTestId(UiTestIds.GoLive.LiveKitToken).FillAsync(BrowserTestConstants.GoLive.LiveKitToken);
             await page.GetByTestId(UiTestIds.GoLive.YoutubeToggle).ClickAsync();
-            await page.GetByTestId(UiTestIds.GoLive.YoutubeUrl).FillAsync(BrowserTestConstants.GoLive.YoutubeUrl);
-            await page.GetByTestId(UiTestIds.GoLive.YoutubeKey).FillAsync(BrowserTestConstants.GoLive.YoutubeKey);
-            await page.GetByTestId(UiTestIds.GoLive.Bitrate).FillAsync(BrowserTestConstants.Streaming.BitrateKbps);
-            await page.GetByTestId(UiTestIds.GoLive.StreamTextOverlay).ClickAsync();
+            await page.GetByTestId(UiTestIds.GoLive.RecordingToggle).ClickAsync();
 
-            var liveKitSourceToggle = page.Locator($"[data-testid^='{UiTestIds.GoLive.ProviderSourceToggle(GoLiveTargetCatalog.TargetIds.LiveKit, string.Empty)}']").First;
-            var youtubeSourceToggle = page.Locator($"[data-testid^='{UiTestIds.GoLive.ProviderSourceToggle(GoLiveTargetCatalog.TargetIds.Youtube, string.Empty)}']").First;
-            await Expect(liveKitSourceToggle).ToBeVisibleAsync();
-            await Expect(youtubeSourceToggle).ToBeVisibleAsync();
-            await youtubeSourceToggle.ClickAsync();
-
-            await Expect(page.GetByTestId(UiTestIds.GoLive.LiveKitServer)).ToHaveValueAsync(BrowserTestConstants.GoLive.LiveKitServer);
-            await Expect(page.GetByTestId(UiTestIds.GoLive.YoutubeUrl)).ToHaveValueAsync(BrowserTestConstants.GoLive.YoutubeUrl);
             await page.WaitForFunctionAsync(
-                BrowserTestConstants.GoLive.PersistedTargetsScript,
-                new object[]
-                {
-                    BrowserTestConstants.GoLive.StoredStudioSettingsKey,
-                    BrowserTestConstants.GoLive.LiveKitServer,
-                    BrowserTestConstants.GoLive.LiveKitRoom,
-                    BrowserTestConstants.GoLive.YoutubeUrl,
-                    GoLiveTargetCatalog.TargetIds.LiveKit,
-                    GoLiveTargetCatalog.TargetIds.Youtube
-                },
+                BrowserTestConstants.GoLive.PersistedToggleTargetsScript,
+                BrowserTestConstants.GoLive.StoredStudioSettingsKey,
                 new() { Timeout = BrowserTestConstants.Timing.ExtendedVisibleTimeoutMs });
 
             await page.ReloadAsync(new() { WaitUntil = Microsoft.Playwright.WaitUntilState.NetworkIdle });
 
-            var persistedLiveKitSourceToggle = page.Locator($"[data-testid^='{UiTestIds.GoLive.ProviderSourceToggle(GoLiveTargetCatalog.TargetIds.LiveKit, string.Empty)}']").First;
-            var persistedYoutubeSourceToggle = page.Locator($"[data-testid^='{UiTestIds.GoLive.ProviderSourceToggle(GoLiveTargetCatalog.TargetIds.Youtube, string.Empty)}']").First;
-            await Expect(persistedLiveKitSourceToggle).ToHaveClassAsync(BrowserTestConstants.Regexes.ToggleOnClass);
-            await Expect(persistedYoutubeSourceToggle).Not.ToHaveClassAsync(BrowserTestConstants.Regexes.ToggleOnClass);
+            await Expect(page.GetByTestId(UiTestIds.GoLive.ObsToggle)).ToHaveClassAsync(BrowserTestConstants.Regexes.ToggleOnClass);
+            await Expect(page.GetByTestId(UiTestIds.GoLive.LiveKitToggle)).ToHaveClassAsync(BrowserTestConstants.Regexes.ToggleOnClass);
+            await Expect(page.GetByTestId(UiTestIds.GoLive.YoutubeToggle)).ToHaveClassAsync(BrowserTestConstants.Regexes.ToggleOnClass);
+            await Expect(page.GetByTestId(UiTestIds.GoLive.RecordingToggle)).ToHaveClassAsync(BrowserTestConstants.Regexes.ToggleOnClass);
         }
         finally
         {
@@ -77,13 +54,12 @@ public sealed class GoLiveFlowTests(StandaloneAppFixture fixture) : IClassFixtur
             await page.GotoAsync(BrowserTestConstants.Routes.GoLiveDemo);
             await Expect(page.GetByTestId(UiTestIds.GoLive.Page)).ToBeVisibleAsync();
 
-            var sourceCamera = page.Locator($"[data-testid^='{UiTestIds.GoLive.SourceCamera(string.Empty)}']").First;
-            var sourceButton = sourceCamera.Locator($"[data-testid^='{UiTestIds.GoLive.SourceCameraAction(string.Empty)}']").First;
-            await Expect(sourceButton).ToContainTextAsync("Remove From Live Feed");
+            var sourceButton = page.GetByTestId(UiTestIds.GoLive.SourceCameraAction(BrowserTestConstants.Media.PrimaryCameraId));
+            await Expect(sourceButton).ToContainTextAsync("Remove");
             await sourceButton.ClickAsync();
-            await Expect(sourceButton).ToContainTextAsync("Add To Live Feed");
+            await Expect(sourceButton).ToContainTextAsync("Include");
             await sourceButton.ClickAsync();
-            await Expect(sourceButton).ToContainTextAsync("Remove From Live Feed");
+            await Expect(sourceButton).ToContainTextAsync("Remove");
 
             await page.GetByTestId(UiTestIds.GoLive.OpenRead).ClickAsync();
             await page.WaitForURLAsync(BrowserTestConstants.Routes.Pattern(BrowserTestConstants.Routes.TeleprompterDemo));
@@ -129,8 +105,30 @@ public sealed class GoLiveFlowTests(StandaloneAppFixture fixture) : IClassFixtur
     }
 
     [Fact]
-    public async Task GoLivePage_ShowsEmptyPreviewStateWhenSceneHasNoCamera()
+    public async Task GoLivePage_HidesPreviewRailWhenRightPanelIsCollapsed()
     {
+        var page = await _fixture.NewPageAsync();
+
+        try
+        {
+            await SeedGoLiveSceneForReuseAsync(page);
+            await page.GotoAsync(BrowserTestConstants.Routes.GoLiveDemo);
+            await Expect(page.GetByTestId(UiTestIds.GoLive.Page)).ToBeVisibleAsync();
+            await Expect(page.GetByTestId(UiTestIds.GoLive.PreviewRail)).ToBeVisibleAsync();
+
+            await page.GetByTestId(UiTestIds.GoLive.RightPanelToggle).ClickAsync();
+            await Expect(page.GetByTestId(UiTestIds.GoLive.PreviewRail)).ToHaveCountAsync(0);
+        }
+        finally
+        {
+            await page.Context.CloseAsync();
+        }
+    }
+
+    [Fact]
+    public async Task GoLivePage_WithEmptyScene_AutoSeedsDefaultDevicesAndShowsStudioShell()
+    {
+        UiScenarioArtifacts.ResetScenario(BrowserTestConstants.GoLive.AutoSeedScenario);
         var page = await _fixture.NewPageAsync();
 
         try
@@ -143,9 +141,88 @@ public sealed class GoLiveFlowTests(StandaloneAppFixture fixture) : IClassFixtur
 
             await page.GotoAsync(BrowserTestConstants.Routes.GoLiveDemo);
             await Expect(page.GetByTestId(UiTestIds.GoLive.Page)).ToBeVisibleAsync();
+            await Expect(page.GetByTestId(UiTestIds.GoLive.ProgramCard)).ToBeVisibleAsync();
             await Expect(page.GetByTestId(UiTestIds.GoLive.PreviewCard)).ToBeVisibleAsync();
-            await Expect(page.GetByTestId(UiTestIds.GoLive.PreviewEmpty)).ToBeVisibleAsync();
-            await Expect(page.GetByTestId(UiTestIds.GoLive.PreviewVideo)).ToHaveCountAsync(0);
+
+            var sourceCards = page.Locator($"[data-testid^='{UiTestIds.GoLive.SourceCameraSelect(string.Empty)}']");
+            await Expect(sourceCards.First).ToContainTextAsync(BrowserTestConstants.Media.PrimaryCameraLabel);
+
+            await page.GetByTestId(UiTestIds.GoLive.AudioTab).ClickAsync();
+            await Expect(page.GetByTestId(UiTestIds.GoLive.AudioChannel(BrowserTestConstants.GoLive.MicChannelId)))
+                .ToContainTextAsync(BrowserTestConstants.Media.PrimaryMicrophoneLabel);
+
+            await UiScenarioArtifacts.CapturePageAsync(
+                page,
+                BrowserTestConstants.GoLive.AutoSeedScenario,
+                BrowserTestConstants.GoLive.AutoSeedStudioStep);
+        }
+        finally
+        {
+            await page.Context.CloseAsync();
+        }
+    }
+
+    [Fact]
+    public async Task GoLivePage_SelectsSecondaryCameraAndTakesItToAir()
+    {
+        UiScenarioArtifacts.ResetScenario(BrowserTestConstants.GoLive.CameraSwitchScenario);
+        var page = await _fixture.NewPageAsync();
+
+        try
+        {
+            await SeedGoLiveSceneForReuseAsync(page);
+            await page.GotoAsync(BrowserTestConstants.Routes.GoLiveDemo);
+            await Expect(page.GetByTestId(UiTestIds.GoLive.Page)).ToBeVisibleAsync();
+
+            await page.WaitForFunctionAsync(
+                BrowserTestConstants.Media.ElementUsesVideoDeviceScript,
+                new object[]
+                {
+                    UiDomIds.GoLive.ProgramVideo,
+                    BrowserTestConstants.Media.PrimaryCameraId
+                },
+                new() { Timeout = BrowserTestConstants.Timing.ExtendedVisibleTimeoutMs });
+            await page.WaitForFunctionAsync(
+                BrowserTestConstants.Media.ElementUsesVideoDeviceScript,
+                new object[]
+                {
+                    UiDomIds.GoLive.PreviewVideo,
+                    BrowserTestConstants.Media.PrimaryCameraId
+                },
+                new() { Timeout = BrowserTestConstants.Timing.ExtendedVisibleTimeoutMs });
+
+            await page.GetByTestId(UiTestIds.GoLive.SourceCameraSelect(BrowserTestConstants.GoLive.SecondSourceId)).ClickAsync();
+            await page.WaitForFunctionAsync(
+                BrowserTestConstants.Media.ElementUsesVideoDeviceScript,
+                new object[]
+                {
+                    UiDomIds.GoLive.ProgramVideo,
+                    BrowserTestConstants.Media.SecondaryCameraId
+                },
+                new() { Timeout = BrowserTestConstants.Timing.ExtendedVisibleTimeoutMs });
+            await page.WaitForFunctionAsync(
+                BrowserTestConstants.Media.ElementUsesVideoDeviceScript,
+                new object[]
+                {
+                    UiDomIds.GoLive.PreviewVideo,
+                    BrowserTestConstants.Media.PrimaryCameraId
+                },
+                new() { Timeout = BrowserTestConstants.Timing.ExtendedVisibleTimeoutMs });
+
+            await page.GetByTestId(UiTestIds.GoLive.TakeToAir).ClickAsync();
+            await page.WaitForFunctionAsync(
+                BrowserTestConstants.Media.ElementUsesVideoDeviceScript,
+                new object[]
+                {
+                    UiDomIds.GoLive.PreviewVideo,
+                    BrowserTestConstants.Media.SecondaryCameraId
+                },
+                new() { Timeout = BrowserTestConstants.Timing.ExtendedVisibleTimeoutMs });
+
+            await UiScenarioArtifacts.CapturePageAsync(
+                page,
+                BrowserTestConstants.GoLive.CameraSwitchScenario,
+                BrowserTestConstants.GoLive.CameraSwitchStep);
         }
         finally
         {
@@ -161,22 +238,19 @@ public sealed class GoLiveFlowTests(StandaloneAppFixture fixture) : IClassFixtur
         try
         {
             await SeedGoLiveSceneForReuseAsync(page);
-            var cameraDeviceId = await page.EvaluateAsync<string>(BrowserTestConstants.GoLive.ResolveCameraDeviceScript);
+            await SeedGoLiveOperationalSettingsAsync(page);
             await page.GotoAsync(BrowserTestConstants.Routes.GoLiveDemo);
             await Expect(page.GetByTestId(UiTestIds.GoLive.Page)).ToBeVisibleAsync();
 
             await page.EvaluateAsync(BrowserTestConstants.GoLive.InstallLiveKitHarnessScript);
-            await page.GetByTestId(UiTestIds.GoLive.LiveKitToggle).ClickAsync();
-            await page.GetByTestId(UiTestIds.GoLive.LiveKitServer).FillAsync(BrowserTestConstants.GoLive.LiveKitServer);
-            await page.GetByTestId(UiTestIds.GoLive.LiveKitRoom).FillAsync(BrowserTestConstants.GoLive.LiveKitRoom);
-            await page.GetByTestId(UiTestIds.GoLive.LiveKitToken).FillAsync(BrowserTestConstants.GoLive.LiveKitToken);
+            await Expect(page.GetByTestId(UiTestIds.GoLive.LiveKitToggle)).ToHaveClassAsync(BrowserTestConstants.Regexes.ToggleOnClass);
             await page.GetByTestId(UiTestIds.GoLive.StartStream).ClickAsync();
 
             await page.WaitForFunctionAsync(
                 BrowserTestConstants.Media.HasAudioVideoRequestScript,
                 new object[]
                 {
-                    cameraDeviceId,
+                    BrowserTestConstants.Media.PrimaryCameraId,
                     BrowserTestConstants.Media.PrimaryMicrophoneId
                 },
                 new() { Timeout = BrowserTestConstants.Timing.ExtendedVisibleTimeoutMs });
@@ -208,7 +282,6 @@ public sealed class GoLiveFlowTests(StandaloneAppFixture fixture) : IClassFixtur
         try
         {
             await SeedGoLiveSceneForReuseAsync(page);
-            var cameraDeviceId = await page.EvaluateAsync<string>(BrowserTestConstants.GoLive.ResolveCameraDeviceScript);
             await page.GotoAsync(BrowserTestConstants.Routes.GoLiveDemo);
             await Expect(page.GetByTestId(UiTestIds.GoLive.Page)).ToBeVisibleAsync();
 
@@ -221,7 +294,7 @@ public sealed class GoLiveFlowTests(StandaloneAppFixture fixture) : IClassFixtur
                 BrowserTestConstants.Media.HasAudioVideoRequestScript,
                 new object[]
                 {
-                    cameraDeviceId,
+                    BrowserTestConstants.Media.PrimaryCameraId,
                     BrowserTestConstants.Media.PrimaryMicrophoneId
                 },
                 new() { Timeout = BrowserTestConstants.Timing.ExtendedVisibleTimeoutMs });
@@ -237,7 +310,7 @@ public sealed class GoLiveFlowTests(StandaloneAppFixture fixture) : IClassFixtur
             Assert.True(runtimeState.GetProperty("obs").GetProperty("active").GetBoolean());
             Assert.True(runtimeState.GetProperty("obs").GetProperty("audioAttached").GetBoolean());
             Assert.Equal("obsstudio", runtimeState.GetProperty("obs").GetProperty("environment").GetString());
-            Assert.Equal(cameraDeviceId, runtimeState.GetProperty("videoDeviceId").GetString());
+            Assert.Equal(BrowserTestConstants.Media.PrimaryCameraId, runtimeState.GetProperty("videoDeviceId").GetString());
             Assert.Equal(BrowserTestConstants.Media.PrimaryMicrophoneId, runtimeState.GetProperty("audioDeviceId").GetString());
         }
         finally
@@ -284,7 +357,6 @@ public sealed class GoLiveFlowTests(StandaloneAppFixture fixture) : IClassFixtur
         await page.GotoAsync(BrowserTestConstants.Routes.Library);
         await Expect(page.GetByTestId(UiTestIds.Library.Page)).ToBeVisibleAsync();
 
-        var cameraDeviceId = await page.EvaluateAsync<string>(BrowserTestConstants.GoLive.ResolveCameraDeviceScript);
         await page.EvaluateAsync(
             BrowserTestConstants.GoLive.SeedSceneScript,
             new object[]
@@ -292,9 +364,24 @@ public sealed class GoLiveFlowTests(StandaloneAppFixture fixture) : IClassFixtur
                 BrowserTestConstants.GoLive.SceneStorageKey,
                 BrowserTestConstants.GoLive.FirstSourceId,
                 BrowserTestConstants.GoLive.SecondSourceId,
-                cameraDeviceId
+                BrowserTestConstants.Media.PrimaryCameraId,
+                BrowserTestConstants.Media.SecondaryCameraId
             });
     }
+
+    private static Task SeedGoLiveOperationalSettingsAsync(Microsoft.Playwright.IPage page) =>
+        page.EvaluateAsync(
+            BrowserTestConstants.GoLive.SeedOperationalStudioSettingsScript,
+            new object[]
+            {
+                BrowserTestConstants.GoLive.StoredStudioSettingsKey,
+                BrowserTestConstants.GoLive.LiveKitServer,
+                BrowserTestConstants.GoLive.LiveKitRoom,
+                BrowserTestConstants.GoLive.LiveKitToken,
+                BrowserTestConstants.GoLive.YoutubeUrl,
+                BrowserTestConstants.GoLive.YoutubeKey,
+                BrowserTestConstants.GoLive.FirstSourceId
+            });
 
     [Fact]
     public async Task SettingsPage_LinksIntoGoLiveRoutingAndGoLiveLinksBackToSettings()

--- a/tests/PrompterLive.App.UITests/Scenarios/StudioWorkflowScenarioTests.cs
+++ b/tests/PrompterLive.App.UITests/Scenarios/StudioWorkflowScenarioTests.cs
@@ -222,6 +222,19 @@ public sealed class StudioWorkflowScenarioTests(StandaloneAppFixture fixture) : 
         await SetRangeValueAsync(page.GetByTestId(UiTestIds.Settings.MicLevel), BrowserTestConstants.LiveWorkflow.MicLevelPercent);
         await page.GetByTestId(UiTestIds.Settings.MicDelay(BrowserTestConstants.Media.PrimaryMicrophoneId))
             .FillAsync(BrowserTestConstants.LiveWorkflow.MicDelayMilliseconds);
+
+        await page.EvaluateAsync(
+            BrowserTestConstants.GoLive.SeedOperationalStudioSettingsScript,
+            new object[]
+            {
+                BrowserTestConstants.GoLive.StoredStudioSettingsKey,
+                BrowserTestConstants.GoLive.LiveKitServer,
+                BrowserTestConstants.GoLive.LiveKitRoom,
+                BrowserTestConstants.GoLive.LiveKitToken,
+                BrowserTestConstants.GoLive.YoutubeUrl,
+                BrowserTestConstants.GoLive.YoutubeKey,
+                BrowserTestConstants.GoLive.FirstSourceId
+            });
         await UiScenarioArtifacts.CapturePageAsync(page, BrowserTestConstants.LiveWorkflow.Name, BrowserTestConstants.LiveWorkflow.SettingsConfiguredStep);
     }
 
@@ -235,17 +248,10 @@ public sealed class StudioWorkflowScenarioTests(StandaloneAppFixture fixture) : 
 
     private static async Task ConfigureGoLiveDestinationsAsync(IPage page)
     {
-        await page.GetByTestId(UiTestIds.GoLive.ObsToggle).ClickAsync();
-        await page.GetByTestId(UiTestIds.GoLive.RecordingToggle).ClickAsync();
-        await page.GetByTestId(UiTestIds.GoLive.LiveKitToggle).ClickAsync();
-        await page.GetByTestId(UiTestIds.GoLive.LiveKitServer).FillAsync(BrowserTestConstants.GoLive.LiveKitServer);
-        await page.GetByTestId(UiTestIds.GoLive.LiveKitRoom).FillAsync(BrowserTestConstants.GoLive.LiveKitRoom);
-        await page.GetByTestId(UiTestIds.GoLive.LiveKitToken).FillAsync(BrowserTestConstants.GoLive.LiveKitToken);
-        await page.GetByTestId(UiTestIds.GoLive.YoutubeToggle).ClickAsync();
-        await page.GetByTestId(UiTestIds.GoLive.YoutubeUrl).FillAsync(BrowserTestConstants.GoLive.YoutubeUrl);
-        await page.GetByTestId(UiTestIds.GoLive.YoutubeKey).FillAsync(BrowserTestConstants.GoLive.YoutubeKey);
-        await page.GetByTestId(UiTestIds.GoLive.StreamTextOverlay).ClickAsync();
-        await page.GetByTestId(UiTestIds.GoLive.StreamIncludeCamera).ClickAsync();
+        await Expect(page.GetByTestId(UiTestIds.GoLive.ObsToggle)).ToHaveClassAsync(BrowserTestConstants.Regexes.ToggleOnClass);
+        await Expect(page.GetByTestId(UiTestIds.GoLive.RecordingToggle)).ToHaveClassAsync(BrowserTestConstants.Regexes.ToggleOnClass);
+        await Expect(page.GetByTestId(UiTestIds.GoLive.LiveKitToggle)).ToHaveClassAsync(BrowserTestConstants.Regexes.ToggleOnClass);
+        await Expect(page.GetByTestId(UiTestIds.GoLive.YoutubeToggle)).ToHaveClassAsync(BrowserTestConstants.Regexes.ToggleOnClass);
         await UiScenarioArtifacts.CapturePageAsync(page, BrowserTestConstants.LiveWorkflow.Name, BrowserTestConstants.LiveWorkflow.GoLiveConfiguredStep);
     }
 
@@ -259,7 +265,24 @@ public sealed class StudioWorkflowScenarioTests(StandaloneAppFixture fixture) : 
                 BrowserTestConstants.Media.PrimaryCameraId
             },
             new() { Timeout = BrowserTestConstants.Timing.ExtendedVisibleTimeoutMs });
-        await page.GetByTestId(UiTestIds.GoLive.SourceCameraAction(BrowserTestConstants.Media.PrimaryCameraId)).ClickAsync();
+
+        var sourceButtons = page.Locator($"[data-testid^='{UiTestIds.GoLive.SourceCameraSelect(string.Empty)}']");
+        if (await sourceButtons.CountAsync() < 2)
+        {
+            await page.GetByTestId(UiTestIds.GoLive.AddSource).ClickAsync();
+            await Expect(sourceButtons).ToHaveCountAsync(2);
+        }
+
+        await sourceButtons.Nth(1).ClickAsync();
+        await page.WaitForFunctionAsync(
+            BrowserTestConstants.Media.ElementUsesVideoDeviceScript,
+            new object[]
+            {
+                UiDomIds.GoLive.ProgramVideo,
+                BrowserTestConstants.Media.SecondaryCameraId
+            },
+            new() { Timeout = BrowserTestConstants.Timing.ExtendedVisibleTimeoutMs });
+        await page.GetByTestId(UiTestIds.GoLive.TakeToAir).ClickAsync();
         await page.WaitForFunctionAsync(
             BrowserTestConstants.Media.ElementUsesVideoDeviceScript,
             new object[]

--- a/tests/PrompterLive.App.UITests/Support/BrowserTestConstants.cs
+++ b/tests/PrompterLive.App.UITests/Support/BrowserTestConstants.cs
@@ -191,6 +191,10 @@ internal static partial class BrowserTestConstants
 
     public static class GoLive
     {
+        public const string AutoSeedScenario = "go-live-auto-seed";
+        public const string AutoSeedStudioStep = "01-default-studio-shell";
+        public const string CameraSwitchScenario = "go-live-camera-switch";
+        public const string CameraSwitchStep = "01-secondary-on-air";
         public const string FirstSourceId = "scene-cam-a";
         public const string FrontCameraLabel = "Front camera";
         public const string HostParticipantName = "Host";
@@ -279,12 +283,12 @@ internal static partial class BrowserTestConstants
             }
             """;
         public const string SeedSceneScript = """
-            ([sceneStorageKey, firstSourceId, secondSourceId, cameraDeviceId]) => {
+            ([sceneStorageKey, firstSourceId, secondSourceId, primaryCameraId, secondaryCameraId]) => {
                 window.localStorage.setItem(sceneStorageKey, JSON.stringify({
                     Cameras: [
                         {
                             SourceId: firstSourceId,
-                            DeviceId: cameraDeviceId,
+                            DeviceId: primaryCameraId,
                             Label: 'Front camera',
                             Transform: {
                                 X: 0.82,
@@ -302,7 +306,7 @@ internal static partial class BrowserTestConstants
                         },
                         {
                             SourceId: secondSourceId,
-                            DeviceId: cameraDeviceId,
+                            DeviceId: secondaryCameraId,
                             Label: 'Side camera',
                             Transform: {
                                 X: 0.18,
@@ -361,8 +365,62 @@ internal static partial class BrowserTestConstants
                 ];
             }
             """;
-        public const string PersistedTargetsScript = """
-            ([storageKey, liveKitServer, liveKitRoom, youtubeUrl, liveKitTargetId, youtubeTargetId]) => {
+        public const string SeedOperationalStudioSettingsScript = """
+            ([storageKey, liveKitServer, liveKitRoom, liveKitToken, youtubeUrl, youtubeKey, primarySourceId]) => {
+                window.localStorage.setItem(storageKey, JSON.stringify({
+                    Camera: {
+                        DefaultCameraId: null,
+                        Resolution: 0,
+                        FrameRate: 1,
+                        MirrorCamera: true,
+                        AutoStartOnRead: true
+                    },
+                    Microphone: {
+                        DefaultMicrophoneId: null,
+                        InputLevelPercent: 65,
+                        NoiseSuppression: true,
+                        EchoCancellation: true
+                    },
+                    Streaming: {
+                        OutputMode: 0,
+                        OutputResolution: 0,
+                        BitrateKbps: 6000,
+                        ShowTextOverlay: true,
+                        IncludeCameraInOutput: true,
+                        DestinationSourceSelections: [
+                            { TargetId: 'obs-studio', SourceIds: [primarySourceId] },
+                            { TargetId: 'local-recording', SourceIds: [primarySourceId] },
+                            { TargetId: 'livekit', SourceIds: [primarySourceId] },
+                            { TargetId: 'youtube-live', SourceIds: [primarySourceId] }
+                        ],
+                        RtmpUrl: '',
+                        StreamKey: '',
+                        ObsVirtualCameraEnabled: true,
+                        NdiOutputEnabled: false,
+                        LocalRecordingEnabled: true,
+                        LiveKitEnabled: true,
+                        LiveKitServerUrl: liveKitServer,
+                        LiveKitRoomName: liveKitRoom,
+                        LiveKitToken: liveKitToken,
+                        VdoNinjaEnabled: false,
+                        VdoNinjaRoomName: '',
+                        VdoNinjaPublishUrl: '',
+                        YoutubeEnabled: true,
+                        YoutubeRtmpUrl: youtubeUrl,
+                        YoutubeStreamKey: youtubeKey,
+                        TwitchEnabled: false,
+                        TwitchRtmpUrl: '',
+                        TwitchStreamKey: '',
+                        CustomRtmpEnabled: false,
+                        CustomRtmpName: 'Custom RTMP',
+                        CustomRtmpUrl: '',
+                        CustomRtmpStreamKey: ''
+                    }
+                }));
+            }
+            """;
+        public const string PersistedToggleTargetsScript = """
+            (storageKey) => {
                 const raw = window.localStorage.getItem(storageKey);
                 if (!raw) {
                     return false;
@@ -370,17 +428,11 @@ internal static partial class BrowserTestConstants
 
                 const parsed = JSON.parse(raw);
                 const streaming = parsed?.Streaming;
-                const selections = streaming?.DestinationSourceSelections ?? [];
-                const liveKitSources = selections.find(selection => selection.TargetId === liveKitTargetId)?.SourceIds ?? [];
-                const youtubeSources = selections.find(selection => selection.TargetId === youtubeTargetId)?.SourceIds ?? [];
                 return Boolean(
+                    streaming?.ObsVirtualCameraEnabled === true &&
+                    streaming?.LocalRecordingEnabled === true &&
                     streaming?.LiveKitEnabled === true &&
-                    streaming?.YoutubeEnabled === true &&
-                    streaming?.LiveKitServerUrl === liveKitServer &&
-                    streaming?.LiveKitRoomName === liveKitRoom &&
-                    streaming?.YoutubeRtmpUrl === youtubeUrl &&
-                    liveKitSources.length >= 1 &&
-                    youtubeSources.length === 0);
+                    streaming?.YoutubeEnabled === true);
             }
             """;
         public const string PreviewReadyScript = "(element) => Boolean(element && element.srcObject && element.readyState >= 2)";


### PR DESCRIPTION
## Summary
- port the Go Live routed page to the design-faithful studio shell from new-design/golive.html
- wire the studio to real browser media/runtime state, quick destination arming, camera add/select/take-to-air flows, and honest room/runtime summaries
- add ADR, feature and architecture updates plus Go Live component and Playwright regression coverage

## Verification
- dotnet format /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx
- dotnet build /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx -warnaserror
- dotnet test /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx
- dotnet test /Users/ksemenenko/Developer/PrompterLive/PrompterLive.slnx --collect:"XPlat Code Coverage"