### PR TITLE
Address browser test review fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -423,6 +423,7 @@ Ask first:
 - progress updates that talk about internal skill routing instead of the concrete repo change
 - long exploratory work before producing the concrete vendored files the user explicitly asked for
 - unexpected browser debugger pause hooks in the default dev launch profile; browser debugging must stay explicit opt-in
+- temporary worktrees or throwaway repo copies for normal repo tasks when the current workspace branch is available; work in the active workspace unless the user explicitly asks for isolation
 
 ## Preferred Skills
 

--- a/tests/PrompterOne.App.UITests/Learn/LearnStartupAlignmentTests.cs
+++ b/tests/PrompterOne.App.UITests/Learn/LearnStartupAlignmentTests.cs
@@ -101,13 +101,13 @@ public sealed class LearnStartupAlignmentTests(StandaloneAppFixture fixture) : I
 
                 let animationFramePasses = 0;
                 const captureOnAnimationFrame = () => {
+                    animationFramePasses += 1;
                     capture();
 
                     if (window.__learnStartupTrace.length >= maxSamples || animationFramePasses >= maxAnimationFramePasses) {
                         return;
                     }
 
-                    animationFramePasses += 1;
                     window.requestAnimationFrame(captureOnAnimationFrame);
                 };
 

--- a/tests/PrompterOne.App.UITests/Media/recording-file-harness.js
+++ b/tests/PrompterOne.App.UITests/Media/recording-file-harness.js
@@ -118,12 +118,32 @@
     }
 
     async function waitForNextVideoFrame(videoElement) {
-        if (typeof videoElement.requestVideoFrameCallback === "function") {
-            await new Promise(resolve => videoElement.requestVideoFrameCallback(() => resolve()));
-            return;
-        }
+        await new Promise(resolve => {
+            let completed = false;
 
-        await new Promise(resolve => window.setTimeout(resolve, visibleVideoPollDelayMs));
+            const finish = () => {
+                if (completed) {
+                    return;
+                }
+
+                completed = true;
+                resolve();
+            };
+
+            const timeoutId = window.setTimeout(finish, visibleVideoPollDelayMs);
+            const canAwaitVideoFrame = typeof videoElement.requestVideoFrameCallback === "function"
+                && !videoElement.paused
+                && !videoElement.ended;
+
+            if (!canAwaitVideoFrame) {
+                return;
+            }
+
+            videoElement.requestVideoFrameCallback(() => {
+                window.clearTimeout(timeoutId);
+                finish();
+            });
+        });
     }
 
     async function detectVisibleVideoAcrossFrames(videoElement) {


### PR DESCRIPTION
## Summary
- make the recording file harness advance even when requestVideoFrameCallback never fires
- cap the Learn startup trace RAF loop without the extra pass
- record the current workspace-only branch workflow preference in AGENTS

## Verification
- dotnet test tests/PrompterOne.App.UITests/PrompterOne.App.UITests.csproj --filter "FullyQualifiedName=PrompterOne.App.UITests.GoLiveShellSessionFlowTests.GoLivePage_StartRecording_FilePickerSave_ProducesDecodableProgramVideoAndAudio"
- dotnet test tests/PrompterOne.App.UITests/PrompterOne.App.UITests.csproj --filter "FullyQualifiedName=PrompterOne.App.UITests.LearnStartupAlignmentTests.LearnScreen_DemoStartup_HidesFocusRowUntilOrpLayoutIsReady" --no-build
- dotnet build PrompterOne.slnx -warnaserror
- dotnet test PrompterOne.slnx
- dotnet format PrompterOne.slnx
- dotnet build PrompterOne.slnx -warnaserror
- dotnet test PrompterOne.slnx