### PR TITLE
[codex] Preserve imported front matter titles

### DIFF
--- a/src/PrompterOne.Core/Editor/Services/ScriptDocumentImportService.cs
+++ b/src/PrompterOne.Core/Editor/Services/ScriptDocumentImportService.cs
@@ -27,16 +27,19 @@ public sealed class ScriptDocumentImportService(ScriptImportDescriptorService de
             throw new ArgumentException(UnsupportedFileNameMessage, nameof(fileName));
         }
 
-        var text = ScriptDocumentFileTypes.CanReadAsText(normalizedFileName)
+        var isTextImport = ScriptDocumentFileTypes.CanReadAsText(normalizedFileName);
+        var text = isTextImport
             ? await ReadTextAsync(stream, cancellationToken)
             : await ConvertToMarkdownAsync(stream, normalizedFileName, mimeType, cancellationToken);
         var importedDocumentName = ScriptDocumentFileTypes.BuildImportedDocumentName(normalizedFileName);
         var descriptor = _descriptorService.Build(importedDocumentName, text);
 
-        return descriptor with
-        {
-            Title = ScriptDocumentFileTypes.ResolvePickerTitle(normalizedFileName)
-        };
+        return isTextImport
+            ? descriptor
+            : descriptor with
+            {
+                Title = ScriptDocumentFileTypes.ResolvePickerTitle(normalizedFileName)
+            };
     }
 
     private static async Task<string> ConvertToMarkdownAsync(

--- a/tests/PrompterOne.Core.Tests/Editor/ScriptDocumentImportServiceTests.cs
+++ b/tests/PrompterOne.Core.Tests/Editor/ScriptDocumentImportServiceTests.cs
@@ -14,16 +14,16 @@ public sealed class ScriptDocumentImportServiceTests
     private const string ImportedHeading = "Converted heading should stay in the editor body";
     private const string ImportedParagraph = "MarkItDown should convert this DOCX paragraph into Markdown for the editor.";
     private const string FrontMatterMarkdownFileName = "Quarterly Town Hall.md";
-    private const string FrontMatterMarkdownTitle = "Quarterly Town Hall";
+    private const string FrontMatterMarkdownTitle = "Front matter title should win";
     private const string FrontMatterMarkdownText =
         """
         ---
-        title: "Front matter title should not win"
+        title: "Front matter title should win"
         ---
 
         ## [Opening|140WPM|Professional]
         ### [First block|140WPM|Warm]
-        Imported markdown should keep the file stem as the editor title.
+        Imported markdown should preserve the explicit front matter title in the editor.
         """;
     private const string NativeScriptFileName = "camera-check.tps";
     private const string NativeScriptText =
@@ -94,7 +94,7 @@ public sealed class ScriptDocumentImportServiceTests
     }
 
     [Test]
-    public async Task ImportAsync_MarkdownImport_UsesFileStemTitle_EvenWhenFrontMatterDefinesAnotherTitle()
+    public async Task ImportAsync_MarkdownImport_PreservesFrontMatterTitle_WhenProvided()
     {
         var service = new ScriptDocumentImportService(new ScriptImportDescriptorService());
         await using var stream = new MemoryStream(Encoding.UTF8.GetBytes(FrontMatterMarkdownText));


### PR DESCRIPTION
## Summary
- preserve explicit front matter titles for text-based shell imports
- keep file-stem title fallback for converted non-text imports
- add a core regression test for markdown imports with front matter

## Root Cause
The shell import flow built the correct descriptor first, then unconditionally overwrote the imported title with the picker/file-stem fallback.

## Validation
- dotnet test @./tests/dotnet-test-progress.rsp --project ./tests/PrompterOne.Core.Tests/PrompterOne.Core.Tests.csproj
- dotnet test @./tests/dotnet-test-progress.rsp --project ./tests/PrompterOne.Web.UITests.Shell/PrompterOne.Web.UITests.Shell.csproj
- dotnet format ./PrompterOne.slnx
- dotnet build ./PrompterOne.slnx -warnaserror